### PR TITLE
Remove unused logging setup

### DIFF
--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -58,6 +58,9 @@ Para iniciar el bot:
 python main.py
 ```
 
+Al ejecutarse, `main.py` configura automáticamente el sistema de logging. Los
+mensajes se muestran en la consola utilizando el formato estándar de Python.
+
 ## Estructura
 
 ```

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -60,8 +60,8 @@ class Config:
         # Validación
         self.validate()
         
-        # Configurar logging
-        # self.setup_logging()  # La configuración de logging ahora está centralizada en `main.py`
+
+        # Configuración de logging gestionada desde `main.py`
         
         self._initialized = True
 
@@ -79,10 +79,6 @@ class Config:
         missing = [var for var, val in required_vars.items() if not val]
         if missing:
             raise ValueError(f"⚠️ Faltan variables de entorno: {', '.join(missing)}")
-
-    def setup_logging(self) -> None:
-        """Configurar sistema de logging"""
-        pass  # La configuración de logging ahora está centralizada en `main.py`
 
 # Instancia global
 config = Config()


### PR DESCRIPTION
## Summary
- quitar el método `setup_logging` sin uso en `config.py`
- aclarar en README que la configuración de logging se hace desde `main.py`

## Testing
- `python -m compileall -q 'Sandy bot'`

------
https://chatgpt.com/codex/tasks/task_e_6840aaab10d88330bbe4abc2a8c2781d