### PR TITLE
Agrega validación JSON en GPTHandler

### DIFF
--- a/Sandy bot/requirements.txt
+++ b/Sandy bot/requirements.txt
@@ -9,3 +9,4 @@ notion-client>=1.0.0
 fuzzywuzzy>=0.18.0
 python-Levenshtein>=0.12.0
 pywin32>=300; sys_platform == 'win32'
+jsonschema>=4.0.0

--- a/Sandy bot/sandybot/gpt_handler.py
+++ b/Sandy bot/sandybot/gpt_handler.py
@@ -7,6 +7,7 @@ import asyncio
 from typing import List, Dict, Any, Optional, Union
 from datetime import datetime
 import openai
+from jsonschema import validate, ValidationError
 from .config import config
 
 logger = logging.getLogger(__name__)
@@ -106,7 +107,7 @@ class GPTHandler:
         schema: Dict[str, Any]
     ) -> Optional[Union[Dict, List]]:
         """
-        Procesa y valida una respuesta JSON de GPT
+        Procesa y valida una respuesta JSON de GPT usando ``jsonschema``
 
         Args:
             contenido: La respuesta de GPT en formato JSON
@@ -126,10 +127,13 @@ class GPTHandler:
             
             # Parsear JSON
             data = json.loads(contenido)
-            
-            # TODO: Implementar validación de schema
+
+            # Validar contra el esquema proporcionado
+            validate(instance=data, schema=schema)
             return data
-            
+        except ValidationError as ve:
+            logger.error("JSON no cumple con el esquema: %s", str(ve))
+            return None
         except Exception as e:
             logger.error("Error al procesar respuesta JSON de GPT: %s", str(e))
             return None


### PR DESCRIPTION
## Summary
- valida las respuestas de GPT usando `jsonschema`
- añade la dependencia `jsonschema` a los requisitos

## Testing
- `python -m py_compile 'Sandy bot/sandybot/gpt_handler.py'`


------
https://chatgpt.com/codex/tasks/task_e_6840aacae7f88330b67a63590e96690c