### PR TITLE
fix: registrar errores al modificar doc

### DIFF
--- a/Sandy bot/sandybot/handlers/repetitividad.py
+++ b/Sandy bot/sandybot/handlers/repetitividad.py
@@ -162,6 +162,6 @@ def modificar_informe_con_pythoncom(docx_path, mes_actual, año_actual):
         doc.Close()
         word_app.Quit()
     except Exception as e:
-        print(f"Error al modificar el documento con COM: {e}")
+        logger.error("Error al modificar el documento con COM: %s", e)
     finally:
         pythoncom.CoUninitialize()


### PR DESCRIPTION
## Summary
- reemplazar `print` por `logger.error` en `repetitividad.py`

## Testing
- `python -m py_compile 'Sandy bot/sandybot/handlers/repetitividad.py'`

------
https://chatgpt.com/codex/tasks/task_e_6840aa37fafc8330b6f6a60747b29b47