### PR TITLE
Configuración de ruta para plantilla

### DIFF
--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -48,6 +48,7 @@ DB_PORT=5432
 DB_NAME=sandybot
 DB_USER=your_db_user
 DB_PASSWORD=your_db_password
+PLANTILLA_PATH=C:\Metrotel\Sandy\plantilla_informe.docx
 ```
 
 ## Uso

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -43,7 +43,15 @@ class Config:
         self.ARCHIVO_CONTADOR = self.DATA_DIR / "contador_diario.json"
         self.LOG_FILE = self.LOG_DIR / "sandy.log"
         self.ERRORES_FILE = self.LOG_DIR / "errores_ingresos.log"
-        
+
+        # Plantilla de informes de repetitividad
+        # Permite definir la ruta mediante la variable de entorno "PLANTILLA_PATH"
+        # para adaptar la ubicación sin modificar el código fuente.
+        self.PLANTILLA_PATH = os.getenv(
+            "PLANTILLA_PATH",
+            r"C:\\Metrotel\\Sandy\\plantilla_informe.docx"
+        )
+
         # Configuración GPT
         self.GPT_MODEL = "gpt-4"  # o "gpt-3.5-turbo" según necesidad
         self.GPT_TIMEOUT = 30

--- a/Sandy bot/sandybot/handlers/repetitividad.py
+++ b/Sandy bot/sandybot/handlers/repetitividad.py
@@ -14,8 +14,11 @@ import locale
 from datetime import datetime
 import logging
 
-# Ruta fija a la plantilla Word
-RUTA_PLANTILLA = r"C:\Metrotel\Sandy\plantilla_informe.docx"
+from sandybot.config import config
+
+# Ruta a la plantilla Word definida en la configuración global
+# Permite modificar la ubicación mediante la variable de entorno "PLANTILLA_PATH"
+RUTA_PLANTILLA = config.PLANTILLA_PATH
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- añado `PLANTILLA_PATH` en `Config` para definir la plantilla desde variables de entorno
- uso esta configuración en `repetitividad.py`
- documento la variable esperada en `README.md`

## Testing
- `python -m py_compile "Sandy bot"/sandybot/*.py "Sandy bot"/sandybot/handlers/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6840aa28ce3083308d4e32e41e2530dc