### PR TITLE
Actualiza gpt_handler a AsyncOpenAI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,10 @@ Interoperable: Puede integrarse con Google Sheets, Notion, Slack
 
 Archivo: gpt_handler.py
 
+Desde 2025 este archivo emplea ``openai.AsyncOpenAI`` para comunicarse con la
+nueva API 1.x de OpenAI, permitiendo consultas asincrónicas y un manejo de
+errores más robusto.
+
 Funciones clave:
 
 consultar_gpt_con_lineas(lineas, horas):

--- a/Sandy bot/sandybot/gpt_handler.py
+++ b/Sandy bot/sandybot/gpt_handler.py
@@ -19,7 +19,10 @@ class GPTHandler:
     """
     def __init__(self):
         self.cache: Dict[str, tuple] = {}
-        openai.api_key = config.OPENAI_API_KEY
+        # Se crea un cliente asíncrono para la API de OpenAI.
+        # De esta forma se aprovecha la nueva interfaz de la
+        # biblioteca ``openai`` a partir de la versión 1.x.
+        self.client = openai.AsyncOpenAI(api_key=config.OPENAI_API_KEY)
         
     async def consultar_gpt(self, mensaje: str, cache: bool = True) -> str:
         """
@@ -45,7 +48,9 @@ class GPTHandler:
 
         for intento in range(config.GPT_MAX_RETRIES):
             try:
-                respuesta = await openai.ChatCompletion.acreate(
+                # Utiliza el cliente asíncrono creado en ``__init__`` para
+                # solicitar una nueva completitud de chat.
+                respuesta = await self.client.chat.completions.create(
                     model=config.GPT_MODEL,
                     messages=[{"role": "user", "content": mensaje}],
                     temperature=0.3,


### PR DESCRIPTION
## Summary
- actualiza `gpt_handler` para usar `openai.AsyncOpenAI`
- ajusta AGENTS.md con nota sobre la nueva API

## Testing
- `python -m py_compile 'Sandy bot/sandybot/gpt_handler.py'`
- `python -m py_compile 'Sandy bot/sandybot/'*.py`


------
https://chatgpt.com/codex/tasks/task_e_6840c5dfae508330ae77a8a0064c79b2