### PR TITLE
Add obtener_mensaje usage

### DIFF
--- a/Sandy bot/sandybot/handlers/comparador.py
+++ b/Sandy bot/sandybot/handlers/comparador.py
@@ -4,7 +4,10 @@ Handler para la comparación de trazados de fibra óptica.
 from telegram import Update
 from telegram.ext import ContextTypes
 from typing import List
-from sandybot.utils import normalizar_texto
+import logging
+from sandybot.utils import normalizar_texto, obtener_mensaje
+
+logger = logging.getLogger(__name__)
 
 async def iniciar_comparador(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -14,9 +17,16 @@ async def iniciar_comparador(update: Update, context: ContextTypes.DEFAULT_TYPE)
     :param context: Contexto del manejador.
     """
     try:
-        await update.message.reply_text("Iniciando comparación de trazados de fibra óptica. Por favor, envíe los datos necesarios.")
+        mensaje = obtener_mensaje(update)
+        if not mensaje:
+            logger.warning("No se recibió un mensaje en iniciar_comparador.")
+            return
+
+        await mensaje.reply_text(
+            "Iniciando comparación de trazados de fibra óptica. Por favor, envíe los datos necesarios."
+        )
     except Exception as e:
-        await update.message.reply_text(f"Error al iniciar la comparación: {e}")
+        await mensaje.reply_text(f"Error al iniciar la comparación: {e}")
 
 async def manejar_comparacion(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -26,17 +36,22 @@ async def manejar_comparacion(update: Update, context: ContextTypes.DEFAULT_TYPE
     :param context: Contexto del manejador.
     """
     try:
+        mensaje = obtener_mensaje(update)
+        if not mensaje:
+            logger.warning("No se recibió un mensaje en manejar_comparacion.")
+            return
+
         # Validar que el usuario haya enviado datos para comparar
-        if not update.message or not update.message.text:
-            await update.message.reply_text("Por favor, envíe los datos de los trazados a comparar.")
+        if not mensaje.text:
+            await mensaje.reply_text("Por favor, envíe los datos de los trazados a comparar.")
             return
 
         # Normalizar y procesar los datos de entrada
-        datos_entrada: str = normalizar_texto(update.message.text)
+        datos_entrada: str = normalizar_texto(mensaje.text)
         trazados: List[str] = datos_entrada.split("\n")
 
         if len(trazados) < 2:
-            await update.message.reply_text("Se necesitan al menos dos trazados para realizar la comparación.")
+            await mensaje.reply_text("Se necesitan al menos dos trazados para realizar la comparación.")
             return
 
         # Realizar la comparación (lógica de ejemplo)
@@ -48,10 +63,10 @@ async def manejar_comparacion(update: Update, context: ContextTypes.DEFAULT_TYPE
 
         # Enviar los resultados al usuario
         mensaje_resultados = "\n".join(resultados)
-        await update.message.reply_text(f"Resultados de la comparación:\n{mensaje_resultados}")
+        await mensaje.reply_text(f"Resultados de la comparación:\n{mensaje_resultados}")
 
     except Exception as e:
-        await update.message.reply_text(f"Error al procesar la comparación: {e}")
+        await mensaje.reply_text(f"Error al procesar la comparación: {e}")
 
 async def recibir_tracking(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -61,9 +76,16 @@ async def recibir_tracking(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     :param context: Contexto del manejador.
     """
     try:
-        await update.message.reply_text("Recibiendo archivo de tracking. Por favor, espere mientras se procesa.")
+        mensaje = obtener_mensaje(update)
+        if not mensaje:
+            logger.warning("No se recibió un mensaje en recibir_tracking.")
+            return
+
+        await mensaje.reply_text(
+            "Recibiendo archivo de tracking. Por favor, espere mientras se procesa."
+        )
     except Exception as e:
-        await update.message.reply_text(f"Error al recibir el archivo de tracking: {e}")
+        await mensaje.reply_text(f"Error al recibir el archivo de tracking: {e}")
 
 async def procesar_comparacion(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -73,6 +95,12 @@ async def procesar_comparacion(update: Update, context: ContextTypes.DEFAULT_TYP
     :param context: Contexto del manejador.
     """
     try:
-        await update.message.reply_text("Procesando comparación detallada. Por favor, espere.")
+        mensaje = obtener_mensaje(update)
+        if not mensaje:
+            logger.warning("No se recibió un mensaje en procesar_comparacion.")
+            return
+
+        await mensaje.reply_text("Procesando comparación detallada. Por favor, espere.")
     except Exception as e:
-        await update.message.reply_text(f"Error al procesar la comparación: {e}")
+        await mensaje.reply_text(f"Error al procesar la comparación: {e}")
+

--- a/Sandy bot/sandybot/handlers/ingresos.py
+++ b/Sandy bot/sandybot/handlers/ingresos.py
@@ -3,6 +3,10 @@ Handler para la verificación de ingresos.
 """
 from telegram import Update
 from telegram.ext import ContextTypes
+import logging
+from sandybot.utils import obtener_mensaje
+
+logger = logging.getLogger(__name__)
 
 async def manejar_ingresos(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -12,10 +16,15 @@ async def manejar_ingresos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     :param context: Contexto del manejador.
     """
     try:
+        mensaje = obtener_mensaje(update)
+        if not mensaje:
+            logger.warning("No se recibió un mensaje en manejar_ingresos.")
+            return
+
         # Lógica para la verificación de ingresos
-        await update.message.reply_text("Verificación de ingresos en desarrollo.")
+        await mensaje.reply_text("Verificación de ingresos en desarrollo.")
     except Exception as e:
-        await update.message.reply_text(f"Error al verificar ingresos: {e}")
+        await mensaje.reply_text(f"Error al verificar ingresos: {e}")
 
 async def iniciar_verificacion_ingresos(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -25,9 +34,16 @@ async def iniciar_verificacion_ingresos(update: Update, context: ContextTypes.DE
     :param context: Contexto del manejador.
     """
     try:
-        await update.message.reply_text("Iniciando verificación de ingresos. Por favor, envíe el archivo correspondiente.")
+        mensaje = obtener_mensaje(update)
+        if not mensaje:
+            logger.warning("No se recibió un mensaje en iniciar_verificacion_ingresos.")
+            return
+
+        await mensaje.reply_text(
+            "Iniciando verificación de ingresos. Por favor, envíe el archivo correspondiente."
+        )
     except Exception as e:
-        await update.message.reply_text(f"Error al iniciar la verificación de ingresos: {e}")
+        await mensaje.reply_text(f"Error al iniciar la verificación de ingresos: {e}")
 
 async def procesar_ingresos(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -37,6 +53,14 @@ async def procesar_ingresos(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     :param context: Contexto del manejador.
     """
     try:
-        await update.message.reply_text("Procesando ingresos. Esta funcionalidad está en desarrollo.")
+        mensaje = obtener_mensaje(update)
+        if not mensaje:
+            logger.warning("No se recibió un mensaje en procesar_ingresos.")
+            return
+
+        await mensaje.reply_text(
+            "Procesando ingresos. Esta funcionalidad está en desarrollo."
+        )
     except Exception as e:
-        await update.message.reply_text(f"Error al procesar ingresos: {e}")
+        await mensaje.reply_text(f"Error al procesar ingresos: {e}")
+

--- a/Sandy bot/sandybot/utils.py
+++ b/Sandy bot/sandybot/utils.py
@@ -7,6 +7,7 @@ import unicodedata
 from datetime import datetime
 from typing import Dict, Any, Optional
 from pathlib import Path
+from telegram import Update, Message
 
 logger = logging.getLogger(__name__)
 
@@ -72,3 +73,22 @@ def timestamp_log() -> str:
         str: Timestamp en formato YYYY-MM-DD HH:MM:SS
     """
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def obtener_mensaje(update: Update) -> Optional[Message]:
+    """Obtiene el objeto Message desde un Update.
+
+    Esta función permite unificar la extracción del mensaje ya sea
+    proveniente de actualizaciones directas o de callbacks.
+
+    Args:
+        update: Update recibido por el bot.
+
+    Returns:
+        Message o ``None`` si no existe.
+    """
+    if update.message:
+        return update.message
+    if update.callback_query and update.callback_query.message:
+        return update.callback_query.message
+    return None


### PR DESCRIPTION
## Summary
- implement `obtener_mensaje` utility
- use `obtener_mensaje` in comparador and ingresos handlers
- log warning and exit when no message is found

## Testing
- `python -m py_compile 'Sandy bot/sandybot/handlers/comparador.py' 'Sandy bot/sandybot/handlers/ingresos.py' 'Sandy bot/sandybot/utils.py'`

------
https://chatgpt.com/codex/tasks/task_e_6840ca77be388330a4196d6b9c51a5cb