### PR TITLE
Update repetitividad flow

### DIFF
--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -20,6 +20,8 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await iniciar_verificacion_ingresos(update, context)
         
     elif query.data == "informe_repetitividad":
+        user_id = query.from_user.id
+        UserState.set_mode(user_id, "repetitividad")
         await iniciar_repetitividad(update, context)
         
     elif query.data == "informe_sla":

--- a/Sandy bot/sandybot/handlers/document.py
+++ b/Sandy bot/sandybot/handlers/document.py
@@ -3,6 +3,8 @@ Handler para el procesamiento de documentos.
 """
 from telegram import Update
 from telegram.ext import ContextTypes
+from .estado import UserState
+from .repetitividad import procesar_repetitividad
 
 async def manejar_documento(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -13,6 +15,11 @@ async def manejar_documento(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     """
     try:
         if not update.message:
+            return
+
+        user_id = update.message.from_user.id
+        if UserState.get_mode(user_id) == "repetitividad":
+            await procesar_repetitividad(update, context)
             return
 
         # Lógica para el procesamiento de documentos

--- a/Sandy bot/sandybot/handlers/repetitividad.py
+++ b/Sandy bot/sandybot/handlers/repetitividad.py
@@ -16,6 +16,7 @@ import logging
 
 from sandybot.config import config
 from ..utils import obtener_mensaje
+from .estado import UserState
 
 # Ruta a la plantilla Word definida en la configuración global
 # Permite modificar la ubicación mediante la variable de entorno "PLANTILLA_PATH"
@@ -66,7 +67,8 @@ async def iniciar_repetitividad(update: Update, context: ContextTypes.DEFAULT_TY
             message.from_user.id,
         )
         await message.reply_text(
-            "Iniciando generación de informes de repetitividad. Por favor, espere."
+            "Iniciando generación de informes de repetitividad. "
+            "Enviá el archivo Excel para continuar."
         )
     except Exception as e:
         logger.error("Error en iniciar_repetitividad: %s", e)
@@ -84,6 +86,7 @@ async def procesar_repetitividad(update: Update, context: ContextTypes.DEFAULT_T
     if not message:
         logger.warning("No se obtuvo mensaje en procesar_repetitividad.")
         return
+    user_id = message.from_user.id
 
     try:
         if not message.document:
@@ -110,6 +113,7 @@ async def procesar_repetitividad(update: Update, context: ContextTypes.DEFAULT_T
 
         os.remove(tmp_excel.name)
         os.remove(ruta_salida)
+        UserState.set_mode(user_id, "")
 
     except Exception as e:
         if message:


### PR DESCRIPTION
## Summary
- set user mode when choosing informe de repetitividad
- explain to send the Excel file when initiating repetitividad
- route documents to `procesar_repetitividad` if needed
- clear user mode after processing the Excel

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`

------
https://chatgpt.com/codex/tasks/task_e_6840e3e40e48833081640cfaf3d473ae