### PR TITLE
Actualiza README sobre win32com

### DIFF
--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -107,6 +107,9 @@ sandybot/
    - Procesa Excel de casos
    - Genera informe Word
    - Identifica líneas con reclamos múltiples
+   - Nota: la modificación automática del documento usa `win32com` y solo
+     funciona en Windows. En otros sistemas puede generarse el archivo .docx
+     sin esta modificación o realizar los cambios de forma manual.
 
 4. Consultas generales
    - Respuestas técnicas con GPT


### PR DESCRIPTION
## Summary
- agrega nota en la sección de informes de repetitividad explicando que la modificación automática de Word usa `win32com` y funciona sólo en Windows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e44b1aac833099f3a0c3f99f7377