### PR TITLE
Implementa comparación de FO

### DIFF
--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -94,9 +94,9 @@ sandybot/
 ## Funcionalidades
 
 1. Comparación de trazados FO
-   - Compara archivos de trazado
-   - Genera Excel con resultados
-   - Identifica cámaras comunes
+   - En el menú principal elegí "Comparar trazados FO"
+   - Adjuntá los trackings en formato `.txt`
+   - Ejecutá `/procesar` para recibir un Excel con coincidencias y el listado de cámaras
 
 2. Verificación de ingresos
    - Valida ingresos contra trazados

--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -19,7 +19,8 @@ from .handlers import (
     start_handler,
     callback_handler,
     message_handler,
-    document_handler
+    document_handler,
+    procesar_comparacion
 )
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,7 @@ class SandyBot:
         """Configura los handlers del bot"""
         # Comandos básicos
         self.app.add_handler(CommandHandler("start", start_handler))
+        self.app.add_handler(CommandHandler("procesar", procesar_comparacion))
         
         # Callbacks de botones
         self.app.add_handler(CallbackQueryHandler(callback_handler))

--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -14,6 +14,9 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await query.answer()
 
     if query.data == "comparar_fo":
+        user_id = query.from_user.id
+        UserState.set_mode(user_id, "comparador")
+        context.user_data.clear()
         await iniciar_comparador(update, context)
         
     elif query.data == "verificar_ingresos":

--- a/Sandy bot/sandybot/handlers/document.py
+++ b/Sandy bot/sandybot/handlers/document.py
@@ -18,8 +18,12 @@ async def manejar_documento(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             return
 
         user_id = update.message.from_user.id
-        if UserState.get_mode(user_id) == "repetitividad":
+        mode = UserState.get_mode(user_id)
+        if mode == "repetitividad":
             await procesar_repetitividad(update, context)
+            return
+        if mode == "comparador":
+            await recibir_tracking(update, context)
             return
 
         # Lógica para el procesamiento de documentos


### PR DESCRIPTION
## Notes
- Se agregó el comando `/procesar` al bot y se importa el manejador de comparación.
- Ahora el callback de "Comparar trazados FO" activa el modo `comparador` y limpia datos previos.
- `document_handler` envía los archivos al comparador cuando el usuario está en ese modo.
- `comparador.py` guarda los trackings recibidos y genera un Excel con coincidencias usando `pandas` y `fuzzywuzzy`.
- Se actualizó el README con la forma correcta de usar la nueva función.

------
https://chatgpt.com/codex/tasks/task_e_6840e75235288330a8fad39fd3b10b0e