### PR TITLE
Fix user state cleanup on missing tracking files

### DIFF
--- a/Sandy bot/sandybot/handlers/comparador.py
+++ b/Sandy bot/sandybot/handlers/comparador.py
@@ -123,6 +123,8 @@ async def procesar_comparacion(update: Update, context: ContextTypes.DEFAULT_TYP
             await mensaje.reply_text(
                 "¿Procesar qué? Necesito al menos dos archivos de tracking."
             )
+            UserState.set_mode(user_id, "")
+            context.user_data["trackings"] = []
             return
 
         await mensaje.reply_text("Procesando comparación, aguarde...")


### PR DESCRIPTION
## Summary
- reset estado y lista de trackings cuando faltan archivos antes de procesar

## Testing
- `python -m py_compile 'Sandy bot/sandybot/handlers/comparador.py'`

------
https://chatgpt.com/codex/tasks/task_e_6840ef89b45083308c57020c4fb3ce8a