### PR TITLE
Implementar modelo Servicio

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,12 @@ El documento base para generar los reportes de repetitividad se indica
 mediante la variable de entorno `PLANTILLA_PATH`. Si no se define, el
 código toma la ruta por defecto `C:\Metrotel\Sandy\plantilla_informe.docx`
 tal como se especifica en `config.py`.
+
+## Base de datos
+
+Se incluyen dos modelos principales:
+
+1. **Conversacion**: almacena el historial de mensajes del bot.
+2. **Servicio**: registra la ruta del tracking asociada y las cámaras
+   involucradas en cada servicio para facilitar su seguimiento.
+


### PR DESCRIPTION
## Summary
- agregar clase `Servicio` a la base de datos
- crear utilidades para obtener, crear y actualizar un servicio
- documentar en README el nuevo modelo

## Testing
- `python -m py_compile 'Sandy bot/sandybot/database.py'`

------
https://chatgpt.com/codex/tasks/task_e_6841ae21d56c8330bc417055c43dde9a