### PR TITLE
Implementa registro de tracking y solicitud de id_servicio

### DIFF
--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -17,6 +17,18 @@ async def message_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     mensaje_usuario = update.message.text
 
     try:
+        # Registrar ID de servicio si se solicitó anteriormente
+        if context.user_data.get("esperando_id_servicio"):
+            try:
+                context.user_data["id_servicio"] = int(mensaje_usuario.strip())
+                context.user_data["esperando_id_servicio"] = False
+                await update.message.reply_text("ID de servicio almacenado.")
+            except ValueError:
+                await update.message.reply_text(
+                    "ID inválido, ingresá solo números."
+                )
+            return
+
         # Manejo de estado de usuario
         if UserState.is_waiting_detail(user_id):
             await _manejar_detalle_pendiente(update, user_id, mensaje_usuario)


### PR DESCRIPTION
## Resumen
- pide el `id_servicio` cuando se cargan trackings y guarda el número
- previene el procesamiento si no se ingresó un `id_servicio`
- tras generar el Excel, guarda la ruta y las cámaras con `actualizar_tracking`
- notifica al usuario que el tracking quedó registrado

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841af8dc1cc83309eb6b700938e4302