### PR TITLE
Implementar carga de tracking

### DIFF
--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -90,6 +90,7 @@ sandybot/
 
 - `/start`: Muestra el menú principal
 - `/procesar`: Procesa archivos en modo comparador
+- `/cargar_tracking`: Asocia un tracking a un servicio existente
 
 ## Funcionalidades
 
@@ -102,8 +103,12 @@ sandybot/
    - Valida ingresos contra trazados
    - Genera informe de coincidencias
    - Detecta duplicados
+3. Carga de tracking
+   - Seleccioná "Cargar tracking" en el menú principal
+   - Indicá el ID del servicio
+   - Adjuntá el archivo `.txt` con el tracking
 
-3. Informes de repetitividad
+4. Informes de repetitividad
    - Procesa Excel de casos
    - Genera informe Word
    - Identifica líneas con reclamos múltiples
@@ -111,7 +116,7 @@ sandybot/
      funciona en Windows. En otros sistemas puede generarse el archivo .docx
      sin esta modificación o realizar los cambios de forma manual.
 
-4. Consultas generales
+5. Consultas generales
    - Respuestas técnicas con GPT
    - Tono malhumorado característico
    - Registro de conversaciones

--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -20,7 +20,8 @@ from .handlers import (
     callback_handler,
     message_handler,
     document_handler,
-    procesar_comparacion
+    procesar_comparacion,
+    iniciar_carga_tracking
 )
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,7 @@ class SandyBot:
         # Comandos básicos
         self.app.add_handler(CommandHandler("start", start_handler))
         self.app.add_handler(CommandHandler("procesar", procesar_comparacion))
+        self.app.add_handler(CommandHandler("cargar_tracking", iniciar_carga_tracking))
         
         # Callbacks de botones
         self.app.add_handler(CallbackQueryHandler(callback_handler))

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -8,6 +8,7 @@ from .document import document_handler
 from .ingresos import iniciar_verificacion_ingresos, procesar_ingresos
 from .repetitividad import procesar_repetitividad
 from .comparador import iniciar_comparador, recibir_tracking, procesar_comparacion
+from .cargar_tracking import iniciar_carga_tracking, guardar_tracking_servicio
 
 __all__ = [
     'start_handler',
@@ -19,5 +20,7 @@ __all__ = [
     'procesar_repetitividad',
     'iniciar_comparador',
     'recibir_tracking',
-    'procesar_comparacion'
+    'procesar_comparacion',
+    'iniciar_carga_tracking',
+    'guardar_tracking_servicio'
 ]

--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -7,6 +7,7 @@ from .estado import UserState
 from .ingresos import iniciar_verificacion_ingresos
 from .repetitividad import iniciar_repetitividad
 from .comparador import iniciar_comparador
+from .cargar_tracking import iniciar_carga_tracking
 
 async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Maneja los callbacks de los botones del menú"""
@@ -21,12 +22,15 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         
     elif query.data == "verificar_ingresos":
         await iniciar_verificacion_ingresos(update, context)
-        
+
     elif query.data == "informe_repetitividad":
         user_id = query.from_user.id
         UserState.set_mode(user_id, "repetitividad")
         await iniciar_repetitividad(update, context)
-        
+
+    elif query.data == "cargar_tracking":
+        await iniciar_carga_tracking(update, context)
+
     elif query.data == "informe_sla":
         await query.edit_message_text(
             "🔧 Función 'Informe de SLA' aún no implementada."

--- a/Sandy bot/sandybot/handlers/cargar_tracking.py
+++ b/Sandy bot/sandybot/handlers/cargar_tracking.py
@@ -1,0 +1,60 @@
+"""Handler para la carga de trackings en la base de datos."""
+from telegram import Update
+from telegram.ext import ContextTypes
+import logging
+from ..utils import obtener_mensaje
+from ..tracking_parser import TrackingParser
+from ..config import config
+from ..database import actualizar_tracking
+from .estado import UserState
+
+logger = logging.getLogger(__name__)
+parser = TrackingParser()
+
+async def iniciar_carga_tracking(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Inicia el proceso solicitando el id del servicio."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        logger.warning("No se recibió mensaje en iniciar_carga_tracking.")
+        return
+    user_id = mensaje.from_user.id
+    UserState.set_mode(user_id, "cargar_tracking")
+    context.user_data.clear()
+    await mensaje.reply_text(
+        "Ingresá el ID del servicio al que pertenece este tracking."
+    )
+
+async def guardar_tracking_servicio(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Guarda el tracking en la base de datos."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje or not mensaje.document:
+        return
+
+    user_id = mensaje.from_user.id
+    servicio = context.user_data.get("id_servicio")
+    if servicio is None:
+        await mensaje.reply_text("Primero indicá el ID del servicio.")
+        return
+
+    documento = mensaje.document
+    if not documento.file_name.endswith(".txt"):
+        await mensaje.reply_text("Solo acepto archivos .txt para el tracking.")
+        return
+
+    archivo = await documento.get_file()
+    ruta_destino = config.DATA_DIR / f"tracking_{servicio}.txt"
+    await archivo.download_to_drive(str(ruta_destino))
+
+    try:
+        parser.clear_data()
+        parser.parse_file(str(ruta_destino))
+        camaras = parser._data[0][1]["camara"].astype(str).tolist()
+        actualizar_tracking(servicio, str(ruta_destino), camaras)
+        await mensaje.reply_text("✅ Tracking cargado y guardado correctamente.")
+    except Exception as e:
+        logger.error("Error al guardar tracking: %s", e)
+        await mensaje.reply_text(f"Error al procesar el tracking: {e}")
+    finally:
+        UserState.set_mode(user_id, "")
+        context.user_data.clear()
+        parser.clear_data()

--- a/Sandy bot/sandybot/handlers/document.py
+++ b/Sandy bot/sandybot/handlers/document.py
@@ -6,6 +6,7 @@ from telegram.ext import ContextTypes
 from .estado import UserState
 from .repetitividad import procesar_repetitividad
 from .comparador import recibir_tracking
+from .cargar_tracking import guardar_tracking_servicio
 
 async def manejar_documento(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -25,6 +26,9 @@ async def manejar_documento(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             return
         if mode == "comparador":
             await recibir_tracking(update, context)
+            return
+        if mode == "cargar_tracking":
+            await guardar_tracking_servicio(update, context)
             return
 
         # Lógica para el procesamiento de documentos

--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -17,6 +17,24 @@ async def message_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     mensaje_usuario = update.message.text
 
     try:
+        # Manejo de carga de tracking
+        if UserState.get_mode(user_id) == "cargar_tracking":
+            if "id_servicio" not in context.user_data:
+                try:
+                    context.user_data["id_servicio"] = int(mensaje_usuario)
+                    await update.message.reply_text(
+                        "ID recibido. Enviá ahora el archivo .txt del tracking."
+                    )
+                except ValueError:
+                    await update.message.reply_text(
+                        "El ID debe ser un número válido, probá de nuevo."
+                    )
+            else:
+                await update.message.reply_text(
+                    "Ya tengo el ID. Envía el archivo .txt por favor."
+                )
+            return
+
         # Manejo de estado de usuario
         if UserState.is_waiting_detail(user_id):
             await _manejar_detalle_pendiente(update, user_id, mensaje_usuario)

--- a/Sandy bot/sandybot/handlers/start.py
+++ b/Sandy bot/sandybot/handlers/start.py
@@ -8,8 +8,11 @@ async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Maneja el comando /start mostrando el menú principal"""
     keyboard = [
         [
-            InlineKeyboardButton("📊 Comparar trazados FO", callback_data="comparar_fo"),
-            InlineKeyboardButton("📥 Verificar ingresos", callback_data="verificar_ingresos"),
+           InlineKeyboardButton("📊 Comparar trazados FO", callback_data="comparar_fo"),
+           InlineKeyboardButton("📥 Verificar ingresos", callback_data="verificar_ingresos"),
+        ],
+        [
+           InlineKeyboardButton("📂 Cargar tracking", callback_data="cargar_tracking"),
         ],
         [
            InlineKeyboardButton("🔁 Informe de repetitividad", callback_data="informe_repetitividad"),


### PR DESCRIPTION
## Resumen
- agregar handler `cargar_tracking`
- registrar el comando en `bot.py`
- incluir un botón nuevo en el menú principal
- manejar carga desde `message_handler` y `document_handler`
- actualizar documentación con el nuevo comando

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841afa13928833080b5e6ed88639e5b