### PR TITLE
Fix callback user state setting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,11 @@ Hay planes para crear un "modo supervisor" para validar manualmente ingresos que
 
 🔧 Variables clave
 
+> **Tip de desarrollo:** cuando un handler se invoca mediante un callback,
+> `obtener_mensaje(update)` devuelve el mensaje del bot que contiene el botón.
+> Para asignar el modo correcto al usuario se debe usar
+> `update.effective_user.id`.
+
 ## ⚙️ Agente principal: `gpt_handler.py`
 
 Desde 2025 este módulo utiliza ``openai.AsyncOpenAI`` para acceder a la nueva API 1.x de OpenAI. Gracias a ello, las consultas se realizan de forma asincrónica y se cuenta con un manejo de errores más sólido.

--- a/Sandy bot/sandybot/handlers/cargar_tracking.py
+++ b/Sandy bot/sandybot/handlers/cargar_tracking.py
@@ -19,7 +19,12 @@ async def iniciar_carga_tracking(update: Update, context: ContextTypes.DEFAULT_T
     if not mensaje:
         logger.warning("No se recibió mensaje en iniciar_carga_tracking.")
         return
-    user_id = mensaje.from_user.id
+
+    # ``mensaje`` proviene del botón con el menú, por lo que su ``from_user``
+    # es el propio bot. Utilizamos ``update.effective_user`` para obtener el
+    # ID real del usuario que hizo clic y así mantener su estado correctamente.
+    user_id = update.effective_user.id
+
     UserState.set_mode(user_id, "cargar_tracking")
     context.user_data.clear()
     await mensaje.reply_text("Enviá el archivo .txt del tracking para comenzar.")

--- a/Sandy bot/sandybot/handlers/comparador.py
+++ b/Sandy bot/sandybot/handlers/comparador.py
@@ -27,7 +27,10 @@ async def iniciar_comparador(update: Update, context: ContextTypes.DEFAULT_TYPE)
             logger.warning("No se recibió un mensaje en iniciar_comparador.")
             return
 
-        user_id = mensaje.from_user.id
+        # Si esta función se llama desde un callback, ``mensaje.from_user`` será
+        # el bot. Empleamos ``update.effective_user`` para asignar el modo al
+        # usuario que inició la acción.
+        user_id = update.effective_user.id
         UserState.set_mode(user_id, "comparador")
         context.user_data["trackings"] = []
         await mensaje.reply_text(

--- a/Sandy bot/sandybot/handlers/ingresos.py
+++ b/Sandy bot/sandybot/handlers/ingresos.py
@@ -44,7 +44,10 @@ async def iniciar_verificacion_ingresos(update: Update, context: ContextTypes.DE
             logger.warning("No se recibió un mensaje en iniciar_verificacion_ingresos.")
             return
 
-        user_id = mensaje.from_user.id
+        # El mensaje proviene de un callback, por lo que ``from_user`` apunta
+        # al bot. Usamos ``update.effective_user`` para registrar el modo en el
+        # usuario correcto.
+        user_id = update.effective_user.id
         UserState.set_mode(user_id, "ingresos")
         context.user_data.clear()
 

--- a/Sandy bot/sandybot/handlers/repetitividad.py
+++ b/Sandy bot/sandybot/handlers/repetitividad.py
@@ -39,7 +39,7 @@ async def manejar_repetitividad(update: Update, context: ContextTypes.DEFAULT_TY
     try:
         logger.info(
             "Iniciando manejo de repetitividad para el usuario %s",
-            message.from_user.id,
+            update.effective_user.id,
         )
         await message.reply_text(
             "Generación de informes de repetitividad en desarrollo."
@@ -64,7 +64,7 @@ async def iniciar_repetitividad(update: Update, context: ContextTypes.DEFAULT_TY
     try:
         logger.info(
             "Iniciando repetitividad para el usuario %s",
-            message.from_user.id,
+            update.effective_user.id,
         )
         await message.reply_text(
             "Iniciando generación de informes de repetitividad. "


### PR DESCRIPTION
## Summary
- ensure handlers set user state using `update.effective_user.id`
- clarify callback usage in AGENTS manual

## Testing
- `python -m compileall -q 'Sandy bot/sandybot'`

------
https://chatgpt.com/codex/tasks/task_e_6841bf3159e88330ba025dadc5e447bd