### PR TITLE
Agregar cliente y registro de trackings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ tal como se especifica en `config.py`.
 Se incluyen dos modelos principales:
 
 1. **Conversacion**: almacena el historial de mensajes del bot.
-2. **Servicio**: registra la ruta del tracking asociada y las cámaras
-   involucradas en cada servicio para facilitar su seguimiento.
+2. **Servicio**: registra nombre, cliente y los trackings asociados.
+   También guarda la ruta del informe de comparación y las cámaras
+   involucradas en cada servicio.
 
 ## Carga de tracking
 

--- a/Sandy bot/sandybot/handlers/cargar_tracking.py
+++ b/Sandy bot/sandybot/handlers/cargar_tracking.py
@@ -71,7 +71,7 @@ async def guardar_tracking_servicio(update: Update, context: ContextTypes.DEFAUL
         parser.clear_data()
         parser.parse_file(str(ruta_destino))
         camaras = parser._data[0][1]["camara"].astype(str).tolist()
-        actualizar_tracking(servicio, str(ruta_destino), camaras)
+        actualizar_tracking(servicio, str(ruta_destino), camaras, [str(ruta_destino)])
         await mensaje.reply_text("✅ Tracking cargado y guardado correctamente.")
     except Exception as e:
         logger.error("Error al guardar tracking: %s", e)


### PR DESCRIPTION
## Summary
- incluir campos `cliente` y `trackings` en el modelo Servicio
- registrar trackings txt en los flujos de carga, comparador y verificación
- actualizar documentación con los nuevos campos

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841bf8fe250833082b20fe33fd9af84