### PR TITLE
Agregar verificación de columnas en servicios

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -1,7 +1,7 @@
 """
 Configuración y modelos de la base de datos
 """
-from sqlalchemy import create_engine, Column, Integer, String, DateTime
+from sqlalchemy import create_engine, Column, Integer, String, DateTime, inspect, text
 from sqlalchemy.orm import declarative_base, sessionmaker
 import json
 from datetime import datetime
@@ -58,12 +58,29 @@ class Servicio(Base):
     def __repr__(self):
         return f"<Servicio(id={self.id}, nombre={self.nombre}, cliente={self.cliente})>"
 
+
+def ensure_servicio_columns() -> None:
+    """Comprueba que la tabla ``servicios`` posea todas las columnas del modelo.
+
+    Si falta alguna, la agrega mediante ``ALTER TABLE`` para mantener la base
+    sincronizada con la definición de :class:`Servicio`.
+    """
+    inspector = inspect(engine)
+    actuales = {col["name"] for col in inspector.get_columns("servicios")}
+    definidas = {c.name for c in Servicio.__table__.columns}
+
+    faltantes = definidas - actuales
+    for columna in faltantes:
+        with engine.begin() as conn:
+            conn.execute(text(f"ALTER TABLE servicios ADD COLUMN {columna} VARCHAR"))
+
 def init_db():
     """Inicializa la base de datos y crea las tablas si no existen."""
     # ``bind=engine`` deja explícito que las tablas se crearán usando
     # la conexión configurada en ``engine``. Esto permite que el bot
     # genere la estructura necesaria de forma automática la primera vez.
     Base.metadata.create_all(bind=engine)
+    ensure_servicio_columns()
 
 # Crear las tablas al importar el módulo
 init_db()


### PR DESCRIPTION
## Summary
- verificar y crear columnas faltantes en la tabla `servicios`
- llamar a la verificación al iniciar la base

## Testing
- `python -m py_compile 'Sandy bot/sandybot/database.py'`
- `python -m compileall -q 'Sandy bot/sandybot'`

------
https://chatgpt.com/codex/tasks/task_e_6841d48a824483308675017f6a32b80b