### PR TITLE
Agrega campos carrier y id_carrier en Servicio

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -1,7 +1,7 @@
 """
 Configuración y modelos de la base de datos
 """
-from sqlalchemy import create_engine, Column, Integer, String, DateTime
+from sqlalchemy import create_engine, Column, Integer, String, DateTime, text, inspect
 from sqlalchemy.orm import declarative_base, sessionmaker
 import json
 from datetime import datetime
@@ -53,6 +53,8 @@ class Servicio(Base):
     ruta_tracking = Column(String)
     trackings = Column(String)
     camaras = Column(String)
+    carrier = Column(String)
+    id_carrier = Column(String)
     fecha_creacion = Column(DateTime, default=datetime.utcnow, index=True)
 
     def __repr__(self):
@@ -64,6 +66,17 @@ def init_db():
     # la conexión configurada en ``engine``. Esto permite que el bot
     # genere la estructura necesaria de forma automática la primera vez.
     Base.metadata.create_all(bind=engine)
+    ensure_servicio_columns()
+
+def ensure_servicio_columns() -> None:
+    """Verifica la presencia de columnas opcionales en ``servicios``."""
+    insp = inspect(engine)
+    existing = {col["name"] for col in insp.get_columns("servicios")}
+    with engine.begin() as conn:
+        if "carrier" not in existing:
+            conn.execute(text("ALTER TABLE servicios ADD COLUMN carrier VARCHAR"))
+        if "id_carrier" not in existing:
+            conn.execute(text("ALTER TABLE servicios ADD COLUMN id_carrier VARCHAR"))
 
 # Crear las tablas al importar el módulo
 init_db()
@@ -82,11 +95,13 @@ def crear_servicio(**datos) -> Servicio:
     """Crea un nuevo servicio con los datos recibidos."""
     session = SessionLocal()
     try:
-        if "camaras" in datos and isinstance(datos["camaras"], list):
-            datos["camaras"] = json.dumps(datos["camaras"])
-        if "trackings" in datos and isinstance(datos["trackings"], list):
-            datos["trackings"] = json.dumps(datos["trackings"])
-        servicio = Servicio(**datos)
+        permitidas = {c.name for c in Servicio.__table__.columns}
+        datos_validos = {k: v for k, v in datos.items() if k in permitidas}
+        if "camaras" in datos_validos and isinstance(datos_validos["camaras"], list):
+            datos_validos["camaras"] = json.dumps(datos_validos["camaras"])
+        if "trackings" in datos_validos and isinstance(datos_validos["trackings"], list):
+            datos_validos["trackings"] = json.dumps(datos_validos["trackings"])
+        servicio = Servicio(**datos_validos)
         session.add(servicio)
         session.commit()
         session.refresh(servicio)


### PR DESCRIPTION
## Summary
- incorpora columnas `carrier` e `id_carrier` en el modelo Servicio
- añade `ensure_servicio_columns` para verificar que existan en la base
- actualiza `crear_servicio` para filtrar y aceptar los nuevos campos

## Testing
- `python -m py_compile 'Sandy bot'/sandybot/database.py`


------
https://chatgpt.com/codex/tasks/task_e_6841d49f18ac8330b1dcdfee7b085099