### PR TITLE
Actualizar README con detalles de columnas

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ tal como se especifica en `config.py`.
 Se incluyen dos modelos principales:
 
 1. **Conversacion**: almacena el historial de mensajes del bot.
-2. **Servicio**: registra nombre, cliente y los trackings asociados.
-   También guarda la ruta del informe de comparación y las cámaras
-   involucradas en cada servicio.
+2. **Servicio**: registra nombre, cliente, carrier e ID carrier.
+   También guarda la ruta del informe de comparación, los trackings
+   asociados y las cámaras involucradas en cada servicio.
 
-Al iniciar el bot, las tablas se crean de forma automática mediante
-`Base.metadata.create_all(bind=engine)`.
+Al iniciar el bot, `init_db()` crea las tablas de forma automática y
+ejecuta `ensure_servicio_columns()` para garantizar que la tabla
+`servicios` incluya las columnas `ruta_tracking`, `trackings`, `camaras`,
+`carrier` e `id_carrier`.
 
 ## Carga de tracking
 

--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -7,7 +7,9 @@ Bot de Telegram para gestión de infraestructura de fibra óptica.
 - Integración con Telegram usando python-telegram-bot
 - Procesamiento de lenguaje natural con GPT-4
 - Base de datos PostgreSQL para historial de conversaciones
-- Las tablas se crean automáticamente con `Base.metadata.create_all(bind=engine)`
+- `init_db()` crea las tablas y ejecuta `ensure_servicio_columns()`
+  para verificar que la tabla `servicios` incluya las columnas
+  `ruta_tracking`, `trackings`, `camaras`, `carrier` e `id_carrier`
 - Procesamiento de archivos Excel para informes
 - Generación de documentos Word
 - Integración con Notion para seguimiento de solicitudes
@@ -86,6 +88,17 @@ sandybot/
 │   └── start.py        # Start command
 └── utils.py            # Utility functions
 ```
+
+## Modelos de base de datos
+
+La función `init_db()` crea las tablas automáticamente y ejecuta
+`ensure_servicio_columns()` para asegurar que la tabla `servicios`
+contenga las columnas `ruta_tracking`, `trackings`, `camaras`, `carrier`
+e `id_carrier`.
+
+- **Conversacion**: guarda los mensajes del bot y las respuestas.
+- **Servicio**: almacena nombre, cliente, carrier e ID carrier, además
+  de las cámaras, los trackings y la ruta al informe de comparación.
 
 ## Comandos
 


### PR DESCRIPTION
## Summary
- detallar columnas aseguradas en `init_db()`
- describir campos Carrier e ID Carrier en los modelos

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841d4a5a22c833090d23975125839cd