### PR TITLE
Fix duplicate ensure_servicio_columns

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -86,17 +86,6 @@ def init_db():
     ensure_servicio_columns()
 
 
-def ensure_servicio_columns() -> None:
-    """Verifica la presencia de columnas opcionales en ``servicios``."""
-    insp = inspect(engine)
-    existing = {col["name"] for col in insp.get_columns("servicios")}
-    with engine.begin() as conn:
-        if "carrier" not in existing:
-            conn.execute(text("ALTER TABLE servicios ADD COLUMN carrier VARCHAR"))
-        if "id_carrier" not in existing:
-            conn.execute(text("ALTER TABLE servicios ADD COLUMN id_carrier VARCHAR"))
-
-
 # Crear las tablas al importar el módulo
 init_db()
 


### PR DESCRIPTION
## Summary
- remove duplicated ensure_servicio_columns and keep generic version

## Testing
- `python -m py_compile 'Sandy bot/sandybot/database.py'`
- `pip install sqlalchemy` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6841da5b85148330aae0e040d44c0f04