### PR TITLE
Implementar búsqueda de servicio por cámara

### DIFF
--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -117,6 +117,7 @@ e `id_carrier`.
    - Valida ingresos contra trazados
    - Genera informe de coincidencias
    - Detecta duplicados
+   - También podés buscar un servicio escribiendo el nombre de la cámara
 3. Carga de tracking
    - Seleccioná "Cargar tracking" en el menú principal
    - Enviá el archivo `.txt` cuyo nombre contenga el ID (ej.: `FO_1234_tramo.txt`)

--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -142,3 +142,23 @@ def actualizar_tracking(
     finally:
         session.close()
 
+
+def buscar_servicios_por_camara(nombre_camara: str) -> list[Servicio]:
+    """Devuelve los servicios que contienen la cámara indicada."""
+    session = SessionLocal()
+    resultados: list[Servicio] = []
+    try:
+        camara_lower = nombre_camara.lower()
+        for servicio in session.query(Servicio).all():
+            if not servicio.camaras:
+                continue
+            try:
+                camaras = json.loads(servicio.camaras)
+            except json.JSONDecodeError:
+                continue
+            if any(camara_lower == str(c).lower() for c in camaras):
+                resultados.append(servicio)
+        return resultados
+    finally:
+        session.close()
+

--- a/Sandy bot/sandybot/handlers/ingresos.py
+++ b/Sandy bot/sandybot/handlers/ingresos.py
@@ -33,6 +33,30 @@ async def manejar_ingresos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     except Exception as e:
         await mensaje.reply_text(f"Error al verificar ingresos: {e}")
 
+
+async def verificar_camara(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Busca servicios por nombre de cámara y responde con las coincidencias."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje or not mensaje.text:
+        logger.warning("No se recibió un nombre de cámara en verificar_camara.")
+        return
+
+    nombre_camara = mensaje.text.strip()
+    from ..database import buscar_servicios_por_camara
+
+    servicios = buscar_servicios_por_camara(nombre_camara)
+
+    if not servicios:
+        await mensaje.reply_text("No encontré servicios con esa cámara.")
+        return
+
+    if len(servicios) == 1:
+        s = servicios[0]
+        await mensaje.reply_text(f"La cámara pertenece al servicio {s.id}: {s.nombre or 'Sin nombre'}")
+    else:
+        listado = "\n".join(f"{s.id}: {s.nombre or 'Sin nombre'}" for s in servicios)
+        await mensaje.reply_text("La cámara figura en varios servicios:\n" + listado)
+
 async def iniciar_verificacion_ingresos(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
     Inicia el proceso de verificación de ingresos.
@@ -55,7 +79,7 @@ async def iniciar_verificacion_ingresos(update: Update, context: ContextTypes.DE
 
         await mensaje.reply_text(
             "Iniciando verificación de ingresos. "
-            "Enviá primero el ID del servicio y luego adjuntá el archivo .txt."
+            "Enviá el nombre de la cámara que querés verificar."
         )
     except Exception as e:
         await mensaje.reply_text(f"Error al iniciar la verificación de ingresos: {e}")

--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -10,6 +10,7 @@ import os
 from .estado import UserState
 from .notion import registrar_accion_pendiente
 from .cargar_tracking import guardar_tracking_servicio
+from .ingresos import verificar_camara
 from ..utils import normalizar_texto
 
 logger = logging.getLogger(__name__)
@@ -55,16 +56,8 @@ async def message_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await _manejar_comparador(update, context, mensaje_usuario)
             return
 
-        if mode == "ingresos" and "id_servicio" not in context.user_data:
-            if mensaje_usuario.isdigit():
-                context.user_data["id_servicio"] = int(mensaje_usuario)
-                await update.message.reply_text(
-                    "ID registrado. Ahora adjuntá el archivo de ingresos (.txt)."
-                )
-            else:
-                await update.message.reply_text(
-                    "Enviá un ID numérico de servicio antes del archivo."
-                )
+        if mode == "ingresos":
+            await verificar_camara(update, context)
             return
 
         # Activar modo Sandy si no está activo␊


### PR DESCRIPTION
## Summary
- agregar `buscar_servicios_por_camara` en `database.py`
- implementar `verificar_camara` para encontrar servicios por cámara
- modificar instrucciones iniciales para verificación de ingresos
- actualizar `message_handler` para usar la nueva función
- documentar la búsqueda por cámara en `README`

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`

------
https://chatgpt.com/codex/tasks/task_e_68420c577e908330aba4bedfcfad7a76