### PR TITLE
Implementación de Identificador Carrier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ Sandy es un agente inteligente que opera en Telegram y automatiza tareas repetit
 - Verificación de ingresos a cámaras de fibra óptica
 - Comparación de trazados (trackings)
 - Generación de informes (repetitividad, coincidencias, etc.)
+- Identificación de servicio Carrier a partir de archivos Excel
 - Clasificación de mensajes ambiguos
 - Enrutamiento de tareas a Notion cuando no pueden resolverse
 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ También se acepta la confirmación escribiendo "sí" o "si".
 Si el ID no existe en la base de datos, Sandy creará el servicio automáticamente
 al guardar el tracking.
 
+## Identificador de servicio Carrier
+
+Desde el menú principal es posible seleccionar **Identificador de servicio Carrier**.
+Esta opción recibe un Excel con las columnas "ID Servicio" e "ID Carrier".
+El bot completa los valores faltantes consultando la base de datos y devuelve el archivo actualizado.
+

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -9,6 +9,7 @@ from .ingresos import iniciar_verificacion_ingresos, procesar_ingresos
 from .repetitividad import procesar_repetitividad
 from .comparador import iniciar_comparador, recibir_tracking, procesar_comparacion
 from .cargar_tracking import iniciar_carga_tracking, guardar_tracking_servicio
+from .id_carrier import iniciar_identificador_carrier, procesar_identificador_carrier
 
 __all__ = [
     'start_handler',
@@ -22,5 +23,7 @@ __all__ = [
     'recibir_tracking',
     'procesar_comparacion',
     'iniciar_carga_tracking',
-    'guardar_tracking_servicio'
+    'guardar_tracking_servicio',
+    'iniciar_identificador_carrier',
+    'procesar_identificador_carrier'
 ]

--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -31,6 +31,10 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif query.data == "cargar_tracking":
         await iniciar_carga_tracking(update, context)
 
+    elif query.data == "id_carrier":
+        from .id_carrier import iniciar_identificador_carrier
+        await iniciar_identificador_carrier(update, context)
+
     elif query.data == "confirmar_tracking":
         user_id = query.from_user.id
         context.user_data["id_servicio"] = context.user_data.get("id_servicio_detected")

--- a/Sandy bot/sandybot/handlers/document.py
+++ b/Sandy bot/sandybot/handlers/document.py
@@ -8,6 +8,7 @@ from .repetitividad import procesar_repetitividad
 from .comparador import recibir_tracking
 from .cargar_tracking import guardar_tracking_servicio
 from .ingresos import procesar_ingresos
+from .id_carrier import procesar_identificador_carrier
 
 async def manejar_documento(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -33,6 +34,9 @@ async def manejar_documento(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             return
         if mode == "ingresos":
             await procesar_ingresos(update, context)
+            return
+        if mode == "id_carrier":
+            await procesar_identificador_carrier(update, context)
             return
 
         # Lógica para el procesamiento de documentos

--- a/Sandy bot/sandybot/handlers/id_carrier.py
+++ b/Sandy bot/sandybot/handlers/id_carrier.py
@@ -1,0 +1,107 @@
+"""Handler para completar IDs de servicio o Carrier desde un Excel."""
+
+from telegram import Update
+from telegram.ext import ContextTypes
+import logging
+import pandas as pd
+import os
+import tempfile
+
+from ..utils import obtener_mensaje
+from ..database import SessionLocal, Servicio
+from .estado import UserState
+
+logger = logging.getLogger(__name__)
+
+async def iniciar_identificador_carrier(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Solicita el archivo Excel con IDs de servicio y carrier."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        logger.warning("No se recibió mensaje en iniciar_identificador_carrier.")
+        return
+
+    user_id = update.effective_user.id
+    UserState.set_mode(user_id, "id_carrier")
+    context.user_data.clear()
+    await mensaje.reply_text(
+        "Enviá el Excel con las columnas 'ID Servicio' e 'ID Carrier' y lo completaré."
+    )
+
+async def procesar_identificador_carrier(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Completa los IDs faltantes en el Excel proporcionado."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje or not mensaje.document:
+        logger.warning("No se recibió documento en procesar_identificador_carrier.")
+        return
+
+    documento = mensaje.document
+    if not documento.file_name.endswith(".xlsx"):
+        await mensaje.reply_text("Solo acepto archivos Excel (.xlsx).")
+        return
+
+    file = await documento.get_file()
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as tmp:
+        await file.download_to_drive(tmp.name)
+
+    try:
+        df = pd.read_excel(tmp.name)
+    except Exception as e:
+        logger.error("Error leyendo Excel: %s", e)
+        await mensaje.reply_text("No pude leer el Excel. Verificá el formato.")
+        os.remove(tmp.name)
+        return
+
+    col_servicio = None
+    col_carrier = None
+    for col in df.columns:
+        nombre = str(col).lower()
+        if "servicio" in nombre:
+            col_servicio = col
+        if "carrier" in nombre:
+            col_carrier = col
+
+    if col_servicio is None or col_carrier is None:
+        await mensaje.reply_text(
+            "El Excel debe tener las columnas 'ID Servicio' e 'ID Carrier'."
+        )
+        os.remove(tmp.name)
+        return
+
+    session = SessionLocal()
+    try:
+        for idx, row in df.iterrows():
+            id_servicio = row.get(col_servicio)
+            id_carrier = row.get(col_carrier)
+
+            if pd.isna(id_servicio) and pd.isna(id_carrier):
+                continue
+
+            if pd.isna(id_servicio) and pd.notna(id_carrier):
+                servicio = (
+                    session.query(Servicio)
+                    .filter(Servicio.id_carrier == str(id_carrier))
+                    .first()
+                )
+                if servicio:
+                    df.at[idx, col_servicio] = servicio.id
+
+            elif pd.isna(id_carrier) and pd.notna(id_servicio):
+                servicio = session.get(Servicio, int(id_servicio))
+                if servicio and servicio.id_carrier:
+                    df.at[idx, col_carrier] = servicio.id_carrier
+    finally:
+        session.close()
+
+    salida = os.path.join(
+        tempfile.gettempdir(), f"identificador_carrier_{mensaje.from_user.id}.xlsx"
+    )
+    df.to_excel(salida, index=False)
+
+    with open(salida, "rb") as f:
+        await mensaje.reply_document(f, filename=os.path.basename(salida))
+
+    os.remove(tmp.name)
+    os.remove(salida)
+
+    UserState.set_mode(mensaje.from_user.id, "")
+    context.user_data.clear()

--- a/Sandy bot/sandybot/handlers/start.py
+++ b/Sandy bot/sandybot/handlers/start.py
@@ -13,6 +13,9 @@ async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         ],
         [
            InlineKeyboardButton("📂 Cargar tracking", callback_data="cargar_tracking"),
+           InlineKeyboardButton(
+               "Identificador de servicio Carrier", callback_data="id_carrier"
+           ),
         ],
         [
            InlineKeyboardButton("🔁 Informe de repetitividad", callback_data="informe_repetitividad"),


### PR DESCRIPTION
## Resumen
- botón **Identificador de servicio Carrier** en el menú principal
- callback y documento para procesar planillas Excel
- nuevo handler `id_carrier.py` que rellena `ID Servicio` o `ID Carrier`
- documentación actualizada en README y AGENTS

## Testing
- `pytest -q` *(sin tests)*
- `flake8` *(falló: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6842127e0a5883309ee13a47b20f6e63