### PR TITLE
Implementar clasificador GPT para flujos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ Sandy es un agente inteligente que opera en Telegram y automatiza tareas repetit
   y reglas simples. Gracias a ello frases como "Comparemos trazados de FO"
   activan automáticamente el flujo "Comparar trazados FO" sin necesidad de
   presionar el botón.
+- Desde 2026 se añadió un módulo de GPT que intenta identificar el flujo
+  correspondiente a partir del texto completo del usuario.
+  Si no puede clasificarlo con certeza, genera una pregunta automática
+  para aclarar la intención antes de continuar.
 
 ## 🎓 Filosofía de diseño
 

--- a/Sandy bot/sandybot/gpt_handler.py
+++ b/Sandy bot/sandybot/gpt_handler.py
@@ -106,6 +106,48 @@ class GPTHandler:
             logger.error("Error al detectar intención: %s", str(e))
             return "neutro"
 
+    async def clasificar_flujo(self, mensaje: str) -> str:
+        """Clasifica un mensaje en uno de los flujos disponibles."""
+        flujos = [
+            "comparar_fo",
+            "verificar_ingresos",
+            "cargar_tracking",
+            "id_carrier",
+            "informe_repetitividad",
+            "informe_sla",
+            "otro",
+        ]
+
+        opciones = ", ".join(flujos)
+        prompt = (
+            "Indicá solo el nombre interno del flujo que coincide con el texto.\n"
+            f"Opciones: {opciones}.\n"
+            f"Texto: '{mensaje}'\n"
+            "Respuesta: "
+        )
+
+        try:
+            respuesta = await self.consultar_gpt(prompt)
+            resultado = respuesta.lower().strip()
+            return resultado if resultado in flujos else "desconocido"
+        except Exception as e:
+            logger.error("Error al clasificar flujo: %s", str(e))
+            return "desconocido"
+
+    async def generar_pregunta_intencion(self, mensaje: str) -> str:
+        """Genera una pregunta de aclaración cuando no se detecta la intención."""
+        prompt = (
+            "El siguiente mensaje no se entiende del todo: "
+            f"'{mensaje}'.\n"
+            "Formulá una pregunta breve y amable para pedir más detalles."
+        )
+
+        try:
+            return await self.consultar_gpt(prompt)
+        except Exception as e:
+            logger.error("Error al generar pregunta de intención: %s", str(e))
+            return "¿Podrías aclarar tu solicitud?"
+
     async def procesar_json_response(
         self, 
         contenido: str, 

--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -61,6 +61,12 @@ async def message_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
         if mode in ("", "sandy"):
             accion = _detectar_accion_natural(mensaje_usuario)
+            if not accion:
+                accion = await gpt.clasificar_flujo(mensaje_usuario)
+                if accion == "desconocido":
+                    pregunta = await gpt.generar_pregunta_intencion(mensaje_usuario)
+                    await update.message.reply_text(pregunta)
+                    return
             if accion:
                 await _ejecutar_accion_natural(accion, update, context)
                 return


### PR DESCRIPTION
## Summary
- usar GPT para clasificar el flujo solicitado
- preguntar con GPT cuando la intencion es poco clara
- actualizar AGENTS.md con el nuevo modulo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684356fb62e08330823c091aae673b0a