### PR TITLE
Add tracking download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ y mostrará dos botones para **Procesar tracking** o **Modificar ID**.
 También se acepta la confirmación escribiendo "sí" o "si".
 Si el ID no existe en la base de datos, Sandy creará el servicio automáticamente
 al guardar el tracking.
+Para recuperar un archivo existente podés usar `/descargar_tracking` y
+especificar el número de servicio.
 
 ## Identificador de servicio Carrier
 

--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -106,6 +106,7 @@ e `id_carrier`.
 - `/start`: Muestra el menú principal
 - `/procesar`: Procesa archivos en modo comparador
 - `/cargar_tracking`: Asocia un tracking a un servicio existente
+- `/descargar_tracking`: Descarga el tracking asociado a un servicio
 
 ## Funcionalidades
 
@@ -128,8 +129,11 @@ e `id_carrier`.
      o **Modificar ID** para ingresar otro número manualmente. También podés
      confirmar escribiendo "sí" o "si".
    - Si el ID no existe en la base, Sandy lo registrará automáticamente.
+4. Descarga de tracking
+   - Elegí "Descargar tracking" desde el menú o escribí `/descargar_tracking`
+   - Indicá el número de servicio y recibirás el `.txt` si está disponible
 
-4. Informes de repetitividad
+5. Informes de repetitividad
    - Procesa Excel de casos
    - Genera informe Word
    - Identifica líneas con reclamos múltiples

--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -21,7 +21,8 @@ from .handlers import (
     message_handler,
     document_handler,
     procesar_comparacion,
-    iniciar_carga_tracking
+    iniciar_carga_tracking,
+    iniciar_descarga_tracking
 )
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ class SandyBot:
         self.app.add_handler(CommandHandler("start", start_handler))
         self.app.add_handler(CommandHandler("procesar", procesar_comparacion))
         self.app.add_handler(CommandHandler("cargar_tracking", iniciar_carga_tracking))
+        self.app.add_handler(CommandHandler("descargar_tracking", iniciar_descarga_tracking))
         
         # Callbacks de botones
         self.app.add_handler(CallbackQueryHandler(callback_handler))

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -9,6 +9,7 @@ from .ingresos import iniciar_verificacion_ingresos, procesar_ingresos
 from .repetitividad import procesar_repetitividad
 from .comparador import iniciar_comparador, recibir_tracking, procesar_comparacion
 from .cargar_tracking import iniciar_carga_tracking, guardar_tracking_servicio
+from .descargar_tracking import iniciar_descarga_tracking, enviar_tracking_servicio
 from .id_carrier import iniciar_identificador_carrier, procesar_identificador_carrier
 
 __all__ = [
@@ -24,6 +25,8 @@ __all__ = [
     'procesar_comparacion',
     'iniciar_carga_tracking',
     'guardar_tracking_servicio',
+    'iniciar_descarga_tracking',
+    'enviar_tracking_servicio',
     'iniciar_identificador_carrier',
     'procesar_identificador_carrier'
 ]

--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -31,6 +31,10 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif query.data == "cargar_tracking":
         await iniciar_carga_tracking(update, context)
 
+    elif query.data == "descargar_tracking":
+        from .descargar_tracking import iniciar_descarga_tracking
+        await iniciar_descarga_tracking(update, context)
+
     elif query.data == "id_carrier":
         from .id_carrier import iniciar_identificador_carrier
         await iniciar_identificador_carrier(update, context)

--- a/Sandy bot/sandybot/handlers/descargar_tracking.py
+++ b/Sandy bot/sandybot/handlers/descargar_tracking.py
@@ -1,0 +1,56 @@
+"""Handler para descargar trackings guardados."""
+
+from telegram import Update
+from telegram.ext import ContextTypes
+import logging
+import os
+
+from ..utils import obtener_mensaje
+from ..database import obtener_servicio
+from .estado import UserState
+
+logger = logging.getLogger(__name__)
+
+async def iniciar_descarga_tracking(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Pide al usuario el ID del servicio para enviar el tracking."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        logger.warning("No se recibió mensaje en iniciar_descarga_tracking.")
+        return
+
+    user_id = update.effective_user.id
+    UserState.set_mode(user_id, "descargar_tracking")
+    context.user_data.clear()
+    await mensaje.reply_text("Indicá el ID del servicio para obtener su tracking.")
+
+async def enviar_tracking_servicio(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Envía el tracking asociado al ID recibido si existe."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje or not mensaje.text:
+        logger.warning("No se recibió ID de servicio en enviar_tracking_servicio.")
+        return
+
+    id_text = mensaje.text.strip()
+    if not id_text.isdigit():
+        await mensaje.reply_text("El ID debe ser numérico.")
+        return
+
+    servicio = obtener_servicio(int(id_text))
+    if not servicio or not servicio.ruta_tracking:
+        await mensaje.reply_text("No hay tracking guardado para ese servicio.")
+        return
+
+    ruta = servicio.ruta_tracking
+    if not os.path.exists(ruta):
+        await mensaje.reply_text("El archivo de tracking no está disponible.")
+        return
+
+    try:
+        with open(ruta, "rb") as f:
+            await mensaje.reply_document(f, filename=os.path.basename(ruta))
+    except Exception as e:
+        logger.error("Error al enviar tracking: %s", e)
+        await mensaje.reply_text(f"Error al enviar el tracking: {e}")
+    finally:
+        UserState.set_mode(update.effective_user.id, "")
+        context.user_data.clear()

--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -52,6 +52,12 @@ async def message_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 await update.message.reply_text("Enviá el archivo .txt del tracking.")
             return
 
+        # Descarga de tracking
+        if UserState.get_mode(user_id) == "descargar_tracking":
+            from .descargar_tracking import enviar_tracking_servicio
+            await enviar_tracking_servicio(update, context)
+            return
+
         # Manejo de estado de usuario
         if UserState.is_waiting_detail(user_id):
             await _manejar_detalle_pendiente(update, context, user_id, mensaje_usuario)
@@ -228,6 +234,11 @@ def _detectar_accion_natural(mensaje: str) -> str | None:
             "subir tracking",
             "adjuntar tracking",
         ],
+        "descargar_tracking": [
+            "descargar tracking",
+            "obtener tracking",
+            "bajar tracking",
+        ],
         "id_carrier": [
             "identificador de servicio carrier",
             "id carrier",
@@ -259,6 +270,12 @@ def _detectar_accion_natural(mensaje: str) -> str | None:
         or "adjuntar" in texto
     ):
         return "cargar_tracking"
+    if "tracking" in texto and (
+        "descarg" in texto
+        or "bajar" in texto
+        or "obten" in texto
+    ):
+        return "descargar_tracking"
     if "carrier" in texto and ("ident" in texto or "id" in texto):
         return "id_carrier"
     if "repetit" in texto and "inform" in texto:
@@ -280,6 +297,9 @@ async def _ejecutar_accion_natural(
         await iniciar_verificacion_ingresos(update, context)
     elif accion == "cargar_tracking":
         await iniciar_carga_tracking(update, context)
+    elif accion == "descargar_tracking":
+        from .descargar_tracking import iniciar_descarga_tracking
+        await iniciar_descarga_tracking(update, context)
     elif accion == "id_carrier":
         await iniciar_identificador_carrier(update, context)
     elif accion == "informe_repetitividad":

--- a/Sandy bot/sandybot/handlers/start.py
+++ b/Sandy bot/sandybot/handlers/start.py
@@ -13,6 +13,9 @@ async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         ],
         [
            InlineKeyboardButton("📂 Cargar tracking", callback_data="cargar_tracking"),
+           InlineKeyboardButton("⬇️ Descargar tracking", callback_data="descargar_tracking"),
+        ],
+        [
            InlineKeyboardButton(
                "Identificador de servicio Carrier", callback_data="id_carrier"
            ),


### PR DESCRIPTION
## Summary
- implement `descargar_tracking` handler to send tracking files
- allow starting the download from menu buttons or natural text
- document the new command in both READMEs
- hook command and button callbacks in bot setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843596ea964833097dfa0f1010dd4bc