### PR TITLE
Ensure workflows log to database

### DIFF
--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -8,6 +8,7 @@ from .ingresos import iniciar_verificacion_ingresos
 from .repetitividad import iniciar_repetitividad
 from .comparador import iniciar_comparador
 from .cargar_tracking import iniciar_carga_tracking, guardar_tracking_servicio
+from ..registrador import registrar_conversacion
 
 async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Maneja los callbacks de los botones del menú"""
@@ -18,38 +19,47 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         user_id = query.from_user.id
         UserState.set_mode(user_id, "comparador")
         context.user_data.clear()
+        registrar_conversacion(user_id, "boton_comparar_fo", "Inicio comparador", "callback")
         await iniciar_comparador(update, context)
         
     elif query.data == "verificar_ingresos":
+        registrar_conversacion(query.from_user.id, "boton_verificar_ingresos", "Inicio ingresos", "callback")
         await iniciar_verificacion_ingresos(update, context)
 
     elif query.data == "informe_repetitividad":
         user_id = query.from_user.id
         UserState.set_mode(user_id, "repetitividad")
+        registrar_conversacion(user_id, "boton_informe_repetitividad", "Inicio repetitividad", "callback")
         await iniciar_repetitividad(update, context)
 
     elif query.data == "cargar_tracking":
+        registrar_conversacion(query.from_user.id, "boton_cargar_tracking", "Inicio carga tracking", "callback")
         await iniciar_carga_tracking(update, context)
 
     elif query.data == "descargar_tracking":
         from .descargar_tracking import iniciar_descarga_tracking
+        registrar_conversacion(query.from_user.id, "boton_descargar_tracking", "Inicio descarga tracking", "callback")
         await iniciar_descarga_tracking(update, context)
 
     elif query.data == "id_carrier":
         from .id_carrier import iniciar_identificador_carrier
+        registrar_conversacion(query.from_user.id, "boton_id_carrier", "Inicio id carrier", "callback")
         await iniciar_identificador_carrier(update, context)
 
     elif query.data == "confirmar_tracking":
         user_id = query.from_user.id
         context.user_data["id_servicio"] = context.user_data.get("id_servicio_detected")
         context.user_data.pop("confirmar_id", None)
+        registrar_conversacion(user_id, "confirmar_tracking", "Confirmar ID", "callback")
         await guardar_tracking_servicio(update, context)
 
     elif query.data == "cambiar_id_tracking":
         context.user_data["confirmar_id"] = True
+        registrar_conversacion(query.from_user.id, "cambiar_id_tracking", "Solicitar ID", "callback")
         await query.edit_message_text("Escribí el ID correcto.")
 
     elif query.data == "informe_sla":
+        registrar_conversacion(query.from_user.id, "informe_sla", "No implementado", "callback")
         await query.edit_message_text(
             "🔧 Función 'Informe de SLA' aún no implementada."
         )
@@ -57,6 +67,7 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif query.data == "otro":
         user_id = query.from_user.id
         UserState.set_mode(user_id, "sandy")
+        registrar_conversacion(user_id, "otro", "Solicitar detalle", "callback")
         await query.edit_message_text(
             "¿Para qué me jodés? Indique su pregunta o solicitud. "
             "Si no puedo hacerla, se enviará como solicitud de implementación."
@@ -69,6 +80,7 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         UserState.set_mode(user_id, "sandy")
         UserState.set_waiting_detail(user_id, True)
         context.user_data["nueva_solicitud"] = True
+        registrar_conversacion(user_id, "nueva_solicitud", "Solicitar detalle", "callback")
         await query.edit_message_text(
             "✍️ Escribí el detalle de la solicitud y la registraré para revisión."
         )

--- a/Sandy bot/sandybot/handlers/descargar_tracking.py
+++ b/Sandy bot/sandybot/handlers/descargar_tracking.py
@@ -7,7 +7,9 @@ import os
 
 from ..utils import obtener_mensaje
 from ..database import obtener_servicio
+from ..registrador import responder_registrando, registrar_conversacion
 from .estado import UserState
+from ..registrador import responder_registrando
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +23,13 @@ async def iniciar_descarga_tracking(update: Update, context: ContextTypes.DEFAUL
     user_id = update.effective_user.id
     UserState.set_mode(user_id, "descargar_tracking")
     context.user_data.clear()
-    await mensaje.reply_text("Indicá el ID del servicio para obtener su tracking.")
+    await responder_registrando(
+        mensaje,
+        user_id,
+        "descargar_tracking",
+        "Indicá el ID del servicio para obtener su tracking.",
+        "descargar_tracking",
+    )
 
 async def enviar_tracking_servicio(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Envía el tracking asociado al ID recibido si existe."""
@@ -32,25 +40,55 @@ async def enviar_tracking_servicio(update: Update, context: ContextTypes.DEFAULT
 
     id_text = mensaje.text.strip()
     if not id_text.isdigit():
-        await mensaje.reply_text("El ID debe ser numérico.")
+        await responder_registrando(
+            mensaje,
+            mensaje.from_user.id,
+            id_text,
+            "El ID debe ser numérico.",
+            "descargar_tracking",
+        )
         return
 
     servicio = obtener_servicio(int(id_text))
     if not servicio or not servicio.ruta_tracking:
-        await mensaje.reply_text("No hay tracking guardado para ese servicio.")
+        await responder_registrando(
+            mensaje,
+            mensaje.from_user.id,
+            id_text,
+            "No hay tracking guardado para ese servicio.",
+            "descargar_tracking",
+        )
         return
 
     ruta = servicio.ruta_tracking
     if not os.path.exists(ruta):
-        await mensaje.reply_text("El archivo de tracking no está disponible.")
+        await responder_registrando(
+            mensaje,
+            mensaje.from_user.id,
+            id_text,
+            "El archivo de tracking no está disponible.",
+            "descargar_tracking",
+        )
         return
 
     try:
         with open(ruta, "rb") as f:
             await mensaje.reply_document(f, filename=os.path.basename(ruta))
+        registrar_conversacion(
+            mensaje.from_user.id,
+            id_text,
+            f"Documento {os.path.basename(ruta)} enviado",
+            "descargar_tracking",
+        )
     except Exception as e:
         logger.error("Error al enviar tracking: %s", e)
-        await mensaje.reply_text(f"Error al enviar el tracking: {e}")
+        await responder_registrando(
+            mensaje,
+            mensaje.from_user.id,
+            id_text,
+            f"Error al enviar el tracking: {e}",
+            "descargar_tracking",
+        )
     finally:
         UserState.set_mode(update.effective_user.id, "")
         context.user_data.clear()

--- a/Sandy bot/sandybot/handlers/repetitividad.py
+++ b/Sandy bot/sandybot/handlers/repetitividad.py
@@ -17,6 +17,7 @@ import logging
 from sandybot.config import config
 from ..utils import obtener_mensaje
 from .estado import UserState
+from ..registrador import responder_registrando, registrar_conversacion
 
 # Ruta a la plantilla Word definida en la configuración global
 # Permite modificar la ubicación mediante la variable de entorno "PLANTILLA_PATH"
@@ -41,13 +42,23 @@ async def manejar_repetitividad(update: Update, context: ContextTypes.DEFAULT_TY
             "Iniciando manejo de repetitividad para el usuario %s",
             update.effective_user.id,
         )
-        await message.reply_text(
-            "Generación de informes de repetitividad en desarrollo."
+        await responder_registrando(
+            message,
+            update.effective_user.id,
+            "informe_repetitividad",
+            "Generación de informes de repetitividad en desarrollo.",
+            "repetitividad",
         )
     except Exception as e:
         logger.error("Error en manejar_repetitividad: %s", e)
         if message:
-            await message.reply_text(f"Error al generar el informe: {e}")
+            await responder_registrando(
+                message,
+                update.effective_user.id,
+                "informe_repetitividad",
+                f"Error al generar el informe: {e}",
+                "repetitividad",
+            )
 
 async def iniciar_repetitividad(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -66,14 +77,23 @@ async def iniciar_repetitividad(update: Update, context: ContextTypes.DEFAULT_TY
             "Iniciando repetitividad para el usuario %s",
             update.effective_user.id,
         )
-        await message.reply_text(
-            "Iniciando generación de informes de repetitividad. "
-            "Enviá el archivo Excel para continuar."
+        await responder_registrando(
+            message,
+            update.effective_user.id,
+            "informe_repetitividad",
+            "Iniciando generación de informes de repetitividad. Enviá el archivo Excel para continuar.",
+            "repetitividad",
         )
     except Exception as e:
         logger.error("Error en iniciar_repetitividad: %s", e)
         if message:
-            await message.reply_text(f"Error al iniciar la generación de informes: {e}")
+            await responder_registrando(
+                message,
+                update.effective_user.id,
+                "informe_repetitividad",
+                f"Error al iniciar la generación de informes: {e}",
+                "repetitividad",
+            )
 
 async def procesar_repetitividad(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -90,15 +110,23 @@ async def procesar_repetitividad(update: Update, context: ContextTypes.DEFAULT_T
 
     try:
         if not message.document:
-            await message.reply_text(
-                "😠 ¿Y el archivo? Adjuntá el Excel, por favor. No soy adivino. #DaleCerebro"
+            await responder_registrando(
+                message,
+                user_id,
+                "procesar_repetitividad",
+                "😠 ¿Y el archivo? Adjuntá el Excel, por favor. No soy adivino. #DaleCerebro",
+                "repetitividad",
             )
             return
 
         archivo = message.document
         if not archivo.file_name.endswith(".xlsx"):
-            await message.reply_text(
-                "🙄 Solo acepto archivos Excel (.xlsx). Mandá bien las cosas. #MeEstásCargando"
+            await responder_registrando(
+                message,
+                user_id,
+                archivo.file_name,
+                "🙄 Solo acepto archivos Excel (.xlsx). Mandá bien las cosas. #MeEstásCargando",
+                "repetitividad",
             )
             return
 
@@ -110,6 +138,12 @@ async def procesar_repetitividad(update: Update, context: ContextTypes.DEFAULT_T
         nombre_final = os.path.basename(ruta_salida)
         with open(ruta_salida, "rb") as docx_file:
             await message.reply_document(document=docx_file, filename=nombre_final)
+        registrar_conversacion(
+            user_id,
+            archivo.file_name,
+            f"Documento {nombre_final} enviado",
+            "repetitividad",
+        )
 
         os.remove(tmp_excel.name)
         os.remove(ruta_salida)
@@ -117,8 +151,12 @@ async def procesar_repetitividad(update: Update, context: ContextTypes.DEFAULT_T
 
     except Exception as e:
         if message:
-            await message.reply_text(
-                "💥 Algo falló generando el informe. No sé cómo hacés para romper hasta esto... #LoQueHayQueAguantar"
+            await responder_registrando(
+                message,
+                user_id,
+                archivo.file_name if 'archivo' in locals() else 'procesar_repetitividad',
+                "💥 Algo falló generando el informe. No sé cómo hacés para romper hasta esto... #LoQueHayQueAguantar",
+                "repetitividad",
             )
 
 

--- a/Sandy bot/sandybot/handlers/start.py
+++ b/Sandy bot/sandybot/handlers/start.py
@@ -3,6 +3,7 @@ Handler principal para el comando /start
 """
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
+from ..registrador import responder_registrando
 
 async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Maneja el comando /start mostrando el menú principal"""
@@ -30,7 +31,11 @@ async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         ]
     ]
     reply_markup = InlineKeyboardMarkup(keyboard)
-    await update.message.reply_text(
+    await responder_registrando(
+        update.message,
+        update.effective_user.id,
+        "/start",
         "Bienvenido al menú principal. ¿Qué acción deseas realizar?",
-        reply_markup=reply_markup
+        "start",
+        reply_markup=reply_markup,
     )

--- a/Sandy bot/sandybot/registrador.py
+++ b/Sandy bot/sandybot/registrador.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 from .database import SessionLocal, Conversacion
 import logging
+from telegram import Message
 
 logger = logging.getLogger(__name__)
 
@@ -34,3 +35,16 @@ def registrar_conversacion(user_id: int, mensaje: str, respuesta: str, modo: str
     finally:
         if session:
             session.close()
+
+
+async def responder_registrando(
+    mensaje_obj: Message,
+    user_id: int,
+    texto_usuario: str,
+    texto_respuesta: str,
+    modo: str,
+    **kwargs,
+) -> None:
+    """Envía una respuesta y registra la interacción."""
+    await mensaje_obj.reply_text(texto_respuesta, **kwargs)
+    registrar_conversacion(user_id, texto_usuario, texto_respuesta, modo)


### PR DESCRIPTION
## Summary
- log todas las interacciones de los flujos
- añadir helper `responder_registrando` para unificar el guardado en DB
- registrar callbacks y comandos con su ID de Telegram

## Testing
- `python -m py_compile sandybot/registrador.py sandybot/handlers/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68435ac0f2cc83309c30a8c0c0b951d0