### PR TITLE
Normalizar cámaras

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -5,6 +5,7 @@ Configuración y modelos de la base de datos
 from sqlalchemy import create_engine, Column, Integer, String, DateTime, text, inspect
 from sqlalchemy.orm import declarative_base, sessionmaker
 import json
+from .utils import normalizar_camara
 from datetime import datetime
 from .config import config
 
@@ -148,7 +149,7 @@ def buscar_servicios_por_camara(nombre_camara: str) -> list[Servicio]:
     session = SessionLocal()
     resultados: list[Servicio] = []
     try:
-        camara_lower = nombre_camara.lower()
+        camara_norm = normalizar_camara(nombre_camara)
         for servicio in session.query(Servicio).all():
             if not servicio.camaras:
                 continue
@@ -156,7 +157,7 @@ def buscar_servicios_por_camara(nombre_camara: str) -> list[Servicio]:
                 camaras = json.loads(servicio.camaras)
             except json.JSONDecodeError:
                 continue
-            if any(camara_lower == str(c).lower() for c in camaras):
+            if any(normalizar_camara(str(c)) == camara_norm for c in camaras):
                 resultados.append(servicio)
         return resultados
     finally:

--- a/Sandy bot/sandybot/handlers/ingresos.py
+++ b/Sandy bot/sandybot/handlers/ingresos.py
@@ -8,7 +8,7 @@ import os
 import tempfile
 import json
 import re
-from sandybot.utils import obtener_mensaje
+from sandybot.utils import obtener_mensaje, normalizar_camara
 from ..database import obtener_servicio, actualizar_tracking, crear_servicio
 from ..config import config
 import shutil
@@ -131,9 +131,9 @@ async def procesar_ingresos(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         except json.JSONDecodeError:
             camaras_servicio = []
 
-        # Mapas en minúsculas para comparar sin distinguir mayúsculas o minúsculas
-        map_archivo = {c.lower(): c for c in camaras_archivo}
-        map_servicio = {c.lower(): c for c in camaras_servicio}
+        # Mapas normalizados para comparar sin acentos ni mayúsculas
+        map_archivo = {normalizar_camara(c): c for c in camaras_archivo}
+        map_servicio = {normalizar_camara(c): c for c in camaras_servicio}
 
         set_archivo = set(map_archivo.keys())
         set_servicio = set(map_servicio.keys())

--- a/Sandy bot/sandybot/utils.py
+++ b/Sandy bot/sandybot/utils.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import Dict, Any, Optional
 from pathlib import Path
 from telegram import Update, Message
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +18,13 @@ def normalizar_texto(texto: str) -> str:
     Normaliza un string para comparaciones (elimina acentos, mayúsculas, etc)
     """
     return unicodedata.normalize('NFKD', texto).encode('ascii', 'ignore').decode('ascii').lower()
+
+def normalizar_camara(texto: str) -> str:
+    """Normaliza nombres de cámara eliminando acentos y equivalencias."""
+    t = normalizar_texto(texto)
+    t = t.replace('cam.', 'camara')
+    t = re.sub(r'\bcam\b', 'camara', t)
+    return t.strip()
 
 def cargar_json(ruta: Path) -> Dict:
     """


### PR DESCRIPTION
## Resumen
- ampliar utilidades para normalizar nombres de cámaras
- usar normalización en búsquedas y verificaciones de ingresos

## Testing
- `python -m py_compile "Sandy bot"/sandybot/utils.py "Sandy bot"/sandybot/database.py "Sandy bot"/sandybot/handlers/ingresos.py`


------
https://chatgpt.com/codex/tasks/task_e_6843574f85d08330977f4765804c563e