### PR TITLE
Fix import duplicado en descargar_tracking

### DIFF
--- a/Sandy bot/sandybot/handlers/descargar_tracking.py
+++ b/Sandy bot/sandybot/handlers/descargar_tracking.py
@@ -9,7 +9,6 @@ from ..utils import obtener_mensaje
 from ..database import obtener_servicio
 from ..registrador import responder_registrando, registrar_conversacion
 from .estado import UserState
-from ..registrador import responder_registrando
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- elimina la segunda importación de `responder_registrando`

## Testing
- `git ls-files '*.py' -z | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68435eae18588330bd8523940229e1fa