### PR TITLE
Refactor para instanciar TrackingParser de forma local

### DIFF
--- a/Sandy bot/sandybot/handlers/cargar_tracking.py
+++ b/Sandy bot/sandybot/handlers/cargar_tracking.py
@@ -13,7 +13,6 @@ from .estado import UserState
 from ..registrador import responder_registrando
 
 logger = logging.getLogger(__name__)
-parser = TrackingParser()
 
 async def iniciar_carga_tracking(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Inicia el proceso solicitando el archivo de tracking."""
@@ -123,6 +122,7 @@ async def guardar_tracking_servicio(update: Update, context: ContextTypes.DEFAUL
 
     Path(ruta_temp).rename(ruta_destino)
 
+    parser = TrackingParser()
     try:
         parser.clear_data()
         parser.parse_file(str(ruta_destino))

--- a/Sandy bot/sandybot/handlers/comparador.py
+++ b/Sandy bot/sandybot/handlers/comparador.py
@@ -20,7 +20,6 @@ from .estado import UserState
 from ..registrador import responder_registrando
 
 logger = logging.getLogger(__name__)
-parser = TrackingParser()
 
 async def iniciar_comparador(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -109,6 +108,8 @@ async def recibir_tracking(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             rutas_extra.append(str(historico))
 
         shutil.move(tmp.name, ruta_destino)
+
+        parser = TrackingParser()
         try:
             parser.clear_data()
             parser.parse_file(str(ruta_destino))
@@ -186,6 +187,7 @@ async def procesar_comparacion(update: Update, context: ContextTypes.DEFAULT_TYP
             "comparador",
         )
 
+        parser = TrackingParser()
         try:
             parser.clear_data()
             for ruta, nombre in trackings:


### PR DESCRIPTION
## Summary
- eliminar las variables globales `parser`
- crear `TrackingParser` dentro de `guardar_tracking_servicio` y `recibir_tracking`
- crear instancia local también en `procesar_comparacion`

## Testing
- `git ls-files '*.py' | xargs -d '\n' python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68435efc1cdc8330aa860e38caff2e70