### PR TITLE
Refactor manejo de sesiones

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -93,17 +93,13 @@ init_db()
 
 def obtener_servicio(id_servicio: int) -> Servicio | None:
     """Devuelve un servicio por su ID o ``None`` si no existe."""
-    session = SessionLocal()
-    try:
+    with SessionLocal() as session:
         return session.get(Servicio, id_servicio)
-    finally:
-        session.close()
 
 
 def crear_servicio(**datos) -> Servicio:
     """Crea un nuevo servicio con los datos recibidos."""
-    session = SessionLocal()
-    try:
+    with SessionLocal() as session:
         permitidas = {c.name for c in Servicio.__table__.columns}
         datos_validos = {k: v for k, v in datos.items() if k in permitidas}
         if "camaras" in datos_validos and isinstance(datos_validos["camaras"], list):
@@ -115,8 +111,6 @@ def crear_servicio(**datos) -> Servicio:
         session.commit()
         session.refresh(servicio)
         return servicio
-    finally:
-        session.close()
 
 
 def actualizar_tracking(
@@ -126,8 +120,7 @@ def actualizar_tracking(
     trackings_txt: list[str] | None = None,
 ) -> None:
     """Actualiza datos del servicio: tracking, cámaras y archivos asociados."""
-    session = SessionLocal()
-    try:
+    with SessionLocal() as session:
         servicio = session.get(Servicio, id_servicio)
         if not servicio:
             return
@@ -140,15 +133,12 @@ def actualizar_tracking(
             existentes.extend(trackings_txt)
             servicio.trackings = json.dumps(existentes)
         session.commit()
-    finally:
-        session.close()
 
 
 def buscar_servicios_por_camara(nombre_camara: str) -> list[Servicio]:
     """Devuelve los servicios que contienen la cámara indicada."""
-    session = SessionLocal()
     resultados: list[Servicio] = []
-    try:
+    with SessionLocal() as session:
         camara_norm = normalizar_camara(nombre_camara)
         for servicio in session.query(Servicio).all():
             if not servicio.camaras:
@@ -163,8 +153,6 @@ def buscar_servicios_por_camara(nombre_camara: str) -> list[Servicio]:
                     resultados.append(servicio)
                     break
         return resultados
-    finally:
-        session.close()
 
 
 def registrar_servicio(id_servicio: int, id_carrier: str | None = None) -> Servicio:
@@ -174,8 +162,7 @@ def registrar_servicio(id_servicio: int, id_carrier: str | None = None) -> Servi
     proporcionado. En caso contrario se genera un nuevo registro con los datos
     recibidos.
     """
-    session = SessionLocal()
-    try:
+    with SessionLocal() as session:
         servicio = session.get(Servicio, id_servicio)
         if servicio:
             if id_carrier is not None:
@@ -190,6 +177,4 @@ def registrar_servicio(id_servicio: int, id_carrier: str | None = None) -> Servi
         session.commit()
         session.refresh(nuevo)
         return nuevo
-    finally:
-        session.close()
 

--- a/Sandy bot/sandybot/registrador.py
+++ b/Sandy bot/sandybot/registrador.py
@@ -15,26 +15,21 @@ def registrar_conversacion(user_id: int, mensaje: str, respuesta: str, modo: str
     :param respuesta: Respuesta enviada por el bot.
     :param modo: Modo de la conversación (ej. GPT, comando).
     """
-    session = None
-    try:
-        session = SessionLocal()
-        nueva_conversacion = Conversacion(
-            user_id=str(user_id),  # Asegurar que user_id sea string para el modelo
-            mensaje=mensaje,
-            respuesta=respuesta,
-            modo=modo,
-            fecha=datetime.utcnow()
-        )
-        session.add(nueva_conversacion)
-        session.commit()
-        logger.info(f"✅ Conversación guardada para user_id: {user_id}")
-    except Exception as e:
-        logger.error(f"❌ Error al guardar conversación para user_id {user_id}: {e}")
-        if session:
-            session.rollback() # Hacer rollback en caso de error
-    finally:
-        if session:
-            session.close()
+    with SessionLocal() as session:
+        try:
+            nueva_conversacion = Conversacion(
+                user_id=str(user_id),  # Asegurar que user_id sea string para el modelo
+                mensaje=mensaje,
+                respuesta=respuesta,
+                modo=modo,
+                fecha=datetime.utcnow()
+            )
+            session.add(nueva_conversacion)
+            session.commit()
+            logger.info(f"✅ Conversación guardada para user_id: {user_id}")
+        except Exception as e:
+            logger.error(f"❌ Error al guardar conversación para user_id {user_id}: {e}")
+            session.rollback()  # Hacer rollback en caso de error
 
 
 async def responder_registrando(


### PR DESCRIPTION
## Summary
- usa `with SessionLocal() as session:` en database.py y registrador.py
- elimina cierres manuales de la sesión

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684369697edc83309314305f8d0f82e0