### PR TITLE
Actualiza modelo GPT configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ instalar las dependencias listadas en `requirements.txt`. Se recomienda usar
 la versión `openai>=1.0.0` para garantizar compatibilidad con la nueva
 API utilizada en `sandybot`.
 
+## Variables de entorno
+
+El comportamiento de SandyBot se ajusta mediante varias variables de entorno:
+
+- `PLANTILLA_PATH`: ruta de la plantilla para los informes de repetitividad. Si
+  no se define, se usa `C:\Metrotel\Sandy\plantilla_informe.docx`.
+- `GPT_MODEL`: modelo de OpenAI a emplear. Por defecto se aplica `gpt-4`.
+
 ## Plantilla de informes de repetitividad
 
 El documento base para generar los reportes de repetitividad se indica

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -58,7 +58,9 @@ class Config:
         )
 
         # Configuración GPT
-        self.GPT_MODEL = "gpt-4"  # o "gpt-3.5-turbo" según necesidad
+        # Permite elegir el modelo vía la variable de entorno "GPT_MODEL".
+        # Si no se define, utiliza "gpt-4" por defecto.
+        self.GPT_MODEL = os.getenv("GPT_MODEL", "gpt-4")
         self.GPT_TIMEOUT = 30
         self.GPT_MAX_RETRIES = 3
         self.GPT_CACHE_TIMEOUT = 3600  # 1 hora


### PR DESCRIPTION
## Summary
- lee la variable `GPT_MODEL` desde el entorno para configurar el modelo de OpenAI
- documenta `GPT_MODEL` y `PLANTILLA_PATH` en una nueva sección de variables de entorno

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436a1c111083309112fd2b29bb48b2