### PR TITLE
Mejora mensaje de validación de variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,17 @@ Luego de enviar el Excel, cada fila se registra en la tabla `servicios`,
 actualizando el `id_carrier` si el servicio existe o creando una entrada nueva
 en caso contrario.
 
+## Errores por variables de entorno faltantes
+
+Al iniciar el bot, `config.py` valida que todas las variables de entorno
+necesarias estén definidas. Si alguna falta, se genera un mensaje como:
+
+```
+⚠️ No se encontraron las siguientes variables de entorno requeridas: VAR1, VAR2.
+Verificá tu archivo .env o las variables del sistema.
+```
+
+Este texto se registra con `logging.error` y luego se lanza una excepción
+`ValueError` con el mismo contenido. Revisá el archivo `.env` o la configuración
+del sistema para corregir el problema.
+

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -91,7 +91,13 @@ class Config:
         
         missing = [var for var, val in required_vars.items() if not val]
         if missing:
-            raise ValueError(f"⚠️ Faltan variables de entorno: {', '.join(missing)}")
+            mensaje = (
+                "⚠️ No se encontraron las siguientes variables de entorno "
+                f"requeridas: {', '.join(missing)}. "
+                "Verificá tu archivo .env o las variables del sistema."
+            )
+            logging.error(mensaje)
+            raise ValueError(mensaje)
 
 # Instancia global
 config = Config()


### PR DESCRIPTION
## Notas
- Codex no encontró errores al ejecutar las pruebas.

## Summary
- se agrega registro de error para variables de entorno faltantes en `config.py`
- se explica en README cómo interpretar este mensaje


------
https://chatgpt.com/codex/tasks/task_e_68436a34d47c8330b89b033338d57e37