### PR TITLE
Soporte para mensajes de voz

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Este repositorio contiene el proyecto SandyBot. Para ejecutarlo se requiere
 instalar las dependencias listadas en `requirements.txt`. Se recomienda usar
 la versión `openai>=1.0.0` para garantizar compatibilidad con la nueva
 API utilizada en `sandybot`.
+Desde esta versión el bot también acepta mensajes de voz, los descarga y
+transcribe automáticamente utilizando la API de OpenAI.
 
 ## Variables de entorno
 

--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -14,6 +14,7 @@ Bot de Telegram para gestión de infraestructura de fibra óptica.
 - Generación de documentos Word
 - Integración con Notion para seguimiento de solicitudes
 - Registro de interacciones para ajustar el tono de las respuestas
+- Transcripción de mensajes de voz usando la API de OpenAI
 
 ## Requisitos
 

--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -20,6 +20,7 @@ from .handlers import (
     callback_handler,
     message_handler,
     document_handler,
+    voice_handler,
     procesar_comparacion,
     iniciar_carga_tracking,
     iniciar_descarga_tracking
@@ -55,6 +56,12 @@ class SandyBot:
         self.app.add_handler(MessageHandler(
             filters.Document.ALL,
             document_handler
+        ))
+
+        # Mensajes de voz
+        self.app.add_handler(MessageHandler(
+            filters.VOICE,
+            voice_handler
         ))
         
         # Error handler

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -5,6 +5,7 @@ from .start import start_handler
 from .callback import callback_handler
 from .message import message_handler
 from .document import document_handler
+from .voice import voice_handler
 from .ingresos import iniciar_verificacion_ingresos, procesar_ingresos
 from .repetitividad import procesar_repetitividad
 from .comparador import iniciar_comparador, recibir_tracking, procesar_comparacion
@@ -17,6 +18,7 @@ __all__ = [
     'callback_handler',
     'message_handler',
     'document_handler',
+    'voice_handler',
     'iniciar_verificacion_ingresos',
     'procesar_ingresos',
     'procesar_repetitividad',

--- a/Sandy bot/sandybot/handlers/voice.py
+++ b/Sandy bot/sandybot/handlers/voice.py
@@ -1,0 +1,41 @@
+"""Handler para mensajes de voz."""
+import logging
+import tempfile
+import openai
+from telegram import Update
+from telegram.ext import ContextTypes
+from ..registrador import responder_registrando
+from .message import message_handler
+
+logger = logging.getLogger(__name__)
+
+async def voice_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Descarga el audio, lo transcribe y pasa el texto a ``message_handler``."""
+    mensaje = update.message
+    if not mensaje or not mensaje.voice:
+        return
+
+    voice = await mensaje.voice.get_file()
+    with tempfile.NamedTemporaryFile(suffix=".ogg") as tmp:
+        await voice.download_to_drive(tmp.name)
+        try:
+            with open(tmp.name, "rb") as audio:
+                transcripcion = await openai.Audio.transcriptions.create(
+                    file=audio,
+                    model="whisper-1"
+                )
+            texto = transcripcion.text.strip()
+        except Exception as e:
+            logger.error("Error al transcribir audio: %s", e)
+            await responder_registrando(
+                mensaje,
+                mensaje.from_user.id,
+                "[voice]",
+                "No pude transcribir el audio. Reintentá más tarde.",
+                "voz",
+            )
+            return
+
+    # Reutilizar el manejador de mensajes como si el usuario hubiera escrito
+    mensaje.text = texto
+    await message_handler(update, context)


### PR DESCRIPTION
## Notas
- Se agregó un nuevo handler para procesar mensajes de voz y transcribirlos con la API de OpenAI.
- Se registró este handler en `bot.py` y se exportó desde `handlers/__init__.py`.
- Se actualizó la documentación en ambos README.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437165baf88330a3d696f2fb26545d