### PR TITLE
Fix normalize and excel generation

### DIFF
--- a/Sandy bot/sandybot/tracking_parser.py
+++ b/Sandy bot/sandybot/tracking_parser.py
@@ -63,16 +63,6 @@ class TrackingParser:
 
     def generate_excel(self, output: str) -> None:
         """Genera un Excel con cada tracking y las coincidencias."""
-        # Durante las pruebas unitarias se simplifica la salida a un archivo
-        # de texto para evitar dependencias pesadas como ``openpyxl``.
-
-        if os.getenv("PYTEST_CURRENT_TEST"):
-            with open(output, "w", encoding="utf-8") as f:
-                for sheet, _ in self._data:
-                    f.write(f"{sheet}\n")
-                f.write("Coincidencias\n")
-            return
-
         coincidencias = pd.DataFrame(
             self._find_common_chambers(), columns=["camara"]
         )

--- a/Sandy bot/sandybot/utils.py
+++ b/Sandy bot/sandybot/utils.py
@@ -31,6 +31,7 @@ def normalizar_camara(texto: str) -> str:
         r"\bav\b": "avenida",
         r"\bgral\.\b": "general",
         r"\bgral\b": "general",
+        r"\bcra\.?\b": "carrera",
     }
     for patron, reemplazo in reemplazos.items():
         t = re.sub(patron, reemplazo, t)


### PR DESCRIPTION
## Summary
- expand street abbreviation normalization to include `cra.` for camera names
- remove test shortcut in `generate_excel` so tests produce a real Excel file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843741a9b888330b86c6e0fff142705