### PR TITLE
Enhance FO comparador flow

### DIFF
--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -110,13 +110,16 @@ e `id_carrier`.
 - `/procesar`: Procesa archivos en modo comparador
 - `/cargar_tracking`: Asocia un tracking a un servicio existente
 - `/descargar_tracking`: Descarga el tracking asociado a un servicio
+- `/comparar_fo`: Inicia la comparación de trazados
 
 ## Funcionalidades
 
 1. Comparación de trazados FO
    - En el menú principal elegí "Comparar trazados FO"
+   - Podés iniciarlo también con `/comparar_fo` o escribiendo "Comparar FO"
    - Adjuntá los trackings en formato `.txt`
-   - Ejecutá `/procesar` para recibir un Excel con coincidencias y el listado de cámaras
+   - Al detectar un servicio con tracking existente aparecerá el botón **Siguiente ➡️** para mantenerlo
+   - Ejecutá `/procesar` o presioná el botón **Procesar 🚀** para recibir un Excel con coincidencias y el listado de cámaras
 
 2. Verificación de ingresos
    - Valida ingresos contra trazados

--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -21,6 +21,7 @@ from .handlers import (
     message_handler,
     document_handler,
     voice_handler,
+    iniciar_comparador,
     procesar_comparacion,
     iniciar_carga_tracking,
     iniciar_descarga_tracking
@@ -39,6 +40,7 @@ class SandyBot:
         """Configura los handlers del bot"""
         # Comandos básicos
         self.app.add_handler(CommandHandler("start", start_handler))
+        self.app.add_handler(CommandHandler("comparar_fo", iniciar_comparador))
         self.app.add_handler(CommandHandler("procesar", procesar_comparacion))
         self.app.add_handler(CommandHandler("cargar_tracking", iniciar_carga_tracking))
         self.app.add_handler(CommandHandler("descargar_tracking", iniciar_descarga_tracking))

--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -1,12 +1,14 @@
 """
 Handler para callbacks de botones
 """
-from telegram import Update
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
+import os
 from .estado import UserState
 from .ingresos import iniciar_verificacion_ingresos
 from .repetitividad import iniciar_repetitividad
-from .comparador import iniciar_comparador
+from .comparador import iniciar_comparador, procesar_comparacion
+from ..database import obtener_servicio
 from .cargar_tracking import iniciar_carga_tracking, guardar_tracking_servicio
 from ..registrador import registrar_conversacion
 
@@ -94,3 +96,35 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await query.edit_message_text(
             "✍️ Escribí el detalle de la solicitud y la registraré para revisión."
         )
+
+    elif query.data == "comparador_siguiente":
+        user_id = query.from_user.id
+        servicio = context.user_data.get("servicio_actual")
+        existente = obtener_servicio(servicio)
+        if existente and existente.ruta_tracking:
+            context.user_data.setdefault("servicios", []).append(servicio)
+            context.user_data.setdefault("trackings", []).append(
+                (existente.ruta_tracking, os.path.basename(existente.ruta_tracking))
+            )
+            context.user_data["esperando_servicio"] = True
+            context.user_data.pop("esperando_respuesta_actualizacion", None)
+            context.user_data.pop("servicio_actual", None)
+            keyboard = InlineKeyboardMarkup(
+                [[InlineKeyboardButton("Procesar 🚀", callback_data="comparador_procesar")]]
+            )
+            registrar_conversacion(user_id, "siguiente", "Servicio agregado", "comparador")
+            await query.edit_message_text(
+                "Servicio agregado. Indicá otro número o ejecutá /procesar.",
+                reply_markup=keyboard,
+            )
+        else:
+            context.user_data["esperando_archivo"] = True
+            context.user_data.pop("esperando_respuesta_actualizacion", None)
+            registrar_conversacion(user_id, "siguiente", "Tracking faltante", "comparador")
+            await query.edit_message_text(
+                "Ese servicio no posee tracking. Debés enviar el archivo .txt.",
+            )
+
+    elif query.data == "comparador_procesar":
+        registrar_conversacion(query.from_user.id, "comparador_procesar", "Procesar", "callback")
+        await procesar_comparacion(update, context)

--- a/Sandy bot/sandybot/handlers/comparador.py
+++ b/Sandy bot/sandybot/handlers/comparador.py
@@ -1,7 +1,7 @@
 """
 Handler para la comparación de trazados de fibra óptica.
 """
-from telegram import Update
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 import logging
 import os

--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -2,7 +2,7 @@
 Handler para mensajes de texto
 """
 import logging
-from telegram import Update
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 from ..gpt_handler import gpt
 from ..database import obtener_servicio, crear_servicio
@@ -201,12 +201,16 @@ async def _manejar_comparador(update: Update, context: ContextTypes.DEFAULT_TYPE
             if existente and existente.ruta_tracking:
                 context.user_data["esperando_respuesta_actualizacion"] = True
                 context.user_data["esperando_servicio"] = False
+                keyboard = InlineKeyboardMarkup(
+                    [[InlineKeyboardButton("Siguiente ➡️", callback_data="comparador_siguiente")]]
+                )
                 await responder_registrando(
                     update.message,
                     user_id,
                     mensaje,
                     f"El servicio {servicio} ya tiene tracking. Enviá 'siguiente' para mantenerlo o adjuntá un .txt para actualizar.",
                     "comparador",
+                    reply_markup=keyboard,
                 )
             else:
                 if not existente:
@@ -242,12 +246,16 @@ async def _manejar_comparador(update: Update, context: ContextTypes.DEFAULT_TYPE
                 context.user_data["esperando_servicio"] = True
                 context.user_data.pop("esperando_respuesta_actualizacion", None)
                 context.user_data.pop("servicio_actual", None)
+                keyboard = InlineKeyboardMarkup(
+                    [[InlineKeyboardButton("Procesar 🚀", callback_data="comparador_procesar")]]
+                )
                 await responder_registrando(
                     update.message,
                     user_id,
                     mensaje,
                     "Servicio agregado. Indicá otro número o ejecutá /procesar.",
                     "comparador",
+                    reply_markup=keyboard,
                 )
             else:
                 await responder_registrando(

--- a/Sandy bot/sandybot/tracking_parser.py
+++ b/Sandy bot/sandybot/tracking_parser.py
@@ -63,16 +63,6 @@ class TrackingParser:
 
     def generate_excel(self, output: str) -> None:
         """Genera un Excel con cada tracking y las coincidencias."""
-        # Durante las pruebas unitarias se simplifica la salida a un archivo
-        # de texto para evitar dependencias pesadas como ``openpyxl``.
-
-        if os.getenv("PYTEST_CURRENT_TEST"):
-            with open(output, "w", encoding="utf-8") as f:
-                for sheet, _ in self._data:
-                    f.write(f"{sheet}\n")
-                f.write("Coincidencias\n")
-            return
-
         coincidencias = pd.DataFrame(
             self._find_common_chambers(), columns=["camara"]
         )


### PR DESCRIPTION
## Summary
- add `/comparar_fo` command
- add inline buttons for existing tracking and processing
- handle new callbacks for comparador actions
- update FO comparison docs
- always generate XLSX files in `TrackingParser`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684374f68d288330ac40e6b12512295e