### PR TITLE
Add incidencias analysis flow

### DIFF
--- a/Sandy bot/sandybot/gpt_handler.py
+++ b/Sandy bot/sandybot/gpt_handler.py
@@ -165,8 +165,8 @@ class GPTHandler:
             return "¿Podrías aclarar tu solicitud?"
 
     async def procesar_json_response(
-        self, 
-        contenido: str, 
+        self,
+        contenido: str,
         schema: Dict[str, Any]
     ) -> Optional[Union[Dict, List]]:
         """
@@ -199,6 +199,33 @@ class GPTHandler:
             return None
         except Exception as e:
             logger.error("Error al procesar respuesta JSON de GPT: %s", str(e))
+            return None
+
+    async def analizar_incidencias(self, texto: str) -> Optional[List[Dict[str, str]]]:
+        """Analiza un texto y extrae una cronología de incidencias."""
+        prompt = (
+            "Extraé la cronología de incidencias del texto y "
+            "devolvé solo un array JSON de objetos con 'fecha' y 'evento'.\n\n"
+            f"Texto:\n{texto}"
+        )
+
+        esquema = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "fecha": {"type": "string"},
+                    "evento": {"type": "string"},
+                },
+                "required": ["fecha", "evento"],
+            },
+        }
+
+        try:
+            respuesta = await self.consultar_gpt(prompt)
+            return await self.procesar_json_response(respuesta, esquema)
+        except Exception as e:
+            logger.error("Error al analizar incidencias: %s", e)
             return None
 
 # Instancia global

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -12,6 +12,7 @@ from .comparador import iniciar_comparador, recibir_tracking, procesar_comparaci
 from .cargar_tracking import iniciar_carga_tracking, guardar_tracking_servicio
 from .descargar_tracking import iniciar_descarga_tracking, enviar_tracking_servicio
 from .id_carrier import iniciar_identificador_carrier, procesar_identificador_carrier
+from .incidencias import iniciar_incidencias, procesar_incidencias
 
 __all__ = [
     'start_handler',
@@ -30,5 +31,7 @@ __all__ = [
     'iniciar_descarga_tracking',
     'enviar_tracking_servicio',
     'iniciar_identificador_carrier',
-    'procesar_identificador_carrier'
+    'procesar_identificador_carrier',
+    'iniciar_incidencias',
+    'procesar_incidencias'
 ]

--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -56,6 +56,11 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         registrar_conversacion(query.from_user.id, "boton_id_carrier", "Inicio id carrier", "callback")
         await iniciar_identificador_carrier(update, context)
 
+    elif query.data == "analizar_incidencias":
+        from .incidencias import iniciar_incidencias
+        registrar_conversacion(query.from_user.id, "analizar_incidencias", "Inicio incidencias", "callback")
+        await iniciar_incidencias(update, context)
+
     elif query.data == "confirmar_tracking":
         user_id = query.from_user.id
         context.user_data["id_servicio"] = context.user_data.get("id_servicio_detected")

--- a/Sandy bot/sandybot/handlers/document.py
+++ b/Sandy bot/sandybot/handlers/document.py
@@ -9,6 +9,7 @@ from .comparador import recibir_tracking
 from .cargar_tracking import guardar_tracking_servicio
 from .ingresos import procesar_ingresos
 from .id_carrier import procesar_identificador_carrier
+from .incidencias import procesar_incidencias
 
 async def manejar_documento(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -41,6 +42,9 @@ async def manejar_documento(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             return
         if mode == "id_carrier":
             await procesar_identificador_carrier(update, context)
+            return
+        if mode == "incidencias":
+            await procesar_incidencias(update, context)
             return
 
         # Lógica para el procesamiento de documentos

--- a/Sandy bot/sandybot/handlers/incidencias.py
+++ b/Sandy bot/sandybot/handlers/incidencias.py
@@ -1,0 +1,97 @@
+"""Manejadores para el análisis de incidencias."""
+
+from telegram import Update
+from telegram.ext import ContextTypes
+import logging
+import tempfile
+import os
+from docx import Document
+
+from ..gpt_handler import gpt
+from ..utils import obtener_mensaje
+from .estado import UserState
+from ..registrador import responder_registrando
+
+logger = logging.getLogger(__name__)
+
+async def iniciar_incidencias(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Inicia el flujo de análisis de incidencias solicitando el .docx."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        logger.warning("No se recibió mensaje en iniciar_incidencias")
+        return
+    user_id = update.effective_user.id
+    UserState.set_mode(user_id, "incidencias")
+    context.user_data.clear()
+    await responder_registrando(
+        mensaje,
+        user_id,
+        "analizar_incidencias",
+        "Enviá el documento .docx con las incidencias para procesar.",
+        "incidencias",
+    )
+
+async def procesar_incidencias(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Procesa el documento de incidencias proporcionado por el usuario."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje or not mensaje.document:
+        logger.warning("No se recibió documento en procesar_incidencias")
+        return
+
+    user_id = mensaje.from_user.id
+    documento = mensaje.document
+    if not documento.file_name.endswith(".docx"):
+        await responder_registrando(
+            mensaje,
+            user_id,
+            documento.file_name,
+            "Solo acepto archivos .docx para analizar incidencias.",
+            "incidencias",
+        )
+        return
+
+    archivo = await documento.get_file()
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".docx") as tmp:
+        await archivo.download_to_drive(tmp.name)
+        ruta_docx = tmp.name
+
+    try:
+        doc = Document(ruta_docx)
+        texto = "\n".join(p.text for p in doc.paragraphs if p.text)
+    except Exception as e:
+        logger.error("Error leyendo docx: %s", e)
+        await responder_registrando(
+            mensaje,
+            user_id,
+            documento.file_name,
+            f"No pude leer el documento: {e}",
+            "incidencias",
+        )
+        return
+
+    try:
+        datos = await gpt.analizar_incidencias(texto)
+        if not datos:
+            raise ValueError("JSON inválido")
+    except Exception as e:
+        logger.error("Fallo analizando incidencias: %s", e)
+        await responder_registrando(
+            mensaje,
+            user_id,
+            documento.file_name,
+            "Hubo un problema analizando las incidencias.",
+            "incidencias",
+        )
+        return
+    finally:
+        os.remove(ruta_docx)
+
+    lineas = [f"{d.get('fecha')}: {d.get('evento')}" for d in datos]
+    respuesta = "Cronología de incidencias:\n" + "\n".join(lineas)
+    await responder_registrando(
+        mensaje,
+        user_id,
+        documento.file_name,
+        respuesta,
+        "incidencias",
+    )

--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -329,6 +329,7 @@ def _detectar_accion_natural(mensaje: str) -> str | None:
             "reporte de repetitividad",
         ],
         "informe_sla": ["informe de sla", "reporte de sla"],
+        "analizar_incidencias": ["analizar incidencias", "incidencias"],
         "start": [
             "start",
             "/start",
@@ -370,6 +371,8 @@ def _detectar_accion_natural(mensaje: str) -> str | None:
         return "informe_repetitividad"
     if "sla" in texto and "inform" in texto:
         return "informe_sla"
+    if "incidenc" in texto and ("analiz" in texto or "docx" in texto):
+        return "analizar_incidencias"
     if "nueva" in texto and "solicitud" in texto:
         return "nueva_solicitud"
     if (
@@ -413,6 +416,10 @@ async def _ejecutar_accion_natural(
         return True
     elif accion == "informe_repetitividad":
         await iniciar_repetitividad(update, context)
+        return True
+    elif accion == "analizar_incidencias":
+        from .incidencias import iniciar_incidencias
+        await iniciar_incidencias(update, context)
         return True
     elif accion == "informe_sla":
         await responder_registrando(

--- a/Sandy bot/sandybot/handlers/start.py
+++ b/Sandy bot/sandybot/handlers/start.py
@@ -26,6 +26,9 @@ async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
            InlineKeyboardButton("🦜 Informe de SLA", callback_data="informe_sla"),
         ],
         [
+           InlineKeyboardButton("📝 Analizar incidencias", callback_data="analizar_incidencias"),
+        ],
+        [
             InlineKeyboardButton("💬 Otro", callback_data="otro"),
             InlineKeyboardButton("📝 Nueva solicitud", callback_data="nueva_solicitud"),
         ]


### PR DESCRIPTION
## Summary
- implement `GPTHandler.analizar_incidencias` to parse incidents
- add new handlers `iniciar_incidencias` and `procesar_incidencias`
- connect incidencias option in callbacks, start menu and message routing
- route document processing for incidencias
- update exports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843763df3e083309b87348299a4ef79