### PR TITLE
Ajuste de nivel de logging para httpx

### DIFF
--- a/Sandy bot/sandybot/logging_config.py
+++ b/Sandy bot/sandybot/logging_config.py
@@ -13,6 +13,9 @@ def setup_logging(level: int = logging.INFO) -> None:
     root.setLevel(level)
     root.handlers.clear()
 
+    # Evitar que bibliotecas como httpx registren tokens o datos sensibles
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
     consola = logging.StreamHandler()
     consola.setFormatter(formatter)
     root.addHandler(consola)


### PR DESCRIPTION
## Resumen
- configuramos el `logger` de **httpx** en `WARNING` para evitar que aparezcan
  las URL con el token de Telegram en los logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843772fa5c083309db974f038a1e5b1