### PR TITLE
fix syntax error in gpt_handler

### DIFF
--- a/Sandy bot/sandybot/gpt_handler.py
+++ b/Sandy bot/sandybot/gpt_handler.py
@@ -227,9 +227,8 @@ class GPTHandler:
 
         try:
             respuesta = await self.consultar_gpt(prompt)
-s
             return await self.procesar_json_response(respuesta, esquema)
-        except Exception as e:
+        except Exception:
             return None
 
 # Instancia global


### PR DESCRIPTION
## Summary
- remove stray character that caused SyntaxError in `gpt_handler.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684378a6341883309f0c5d9e9dfd4cfd