### PR TITLE
Fix numbering in README functionalities

### DIFF
--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -148,7 +148,7 @@ e `id_carrier`.
      funciona en Windows. En otros sistemas puede generarse el archivo .docx
      sin esta modificación o realizar los cambios de forma manual.
 
-5. Consultas generales
+6. Consultas generales
    - Respuestas técnicas con GPT
    - Tono adaptado según interacciones (de cordial a muy malhumorado)
    - Registro de conversaciones


### PR DESCRIPTION
## Summary
- fix numbering in README for 'Sandy bot'

## Testing
- `pytest -q` *(fails: ValueError invalid literal for int() with base 10: '')*

------
https://chatgpt.com/codex/tasks/task_e_68437a76433c8330b8ca08ecaef6cb2c