### PR TITLE
Add docx chronology output

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ en caso contrario.
 
 Esta función genera un resumen de las fallas registradas en reportes de campo. Actualmente se debe adjuntar un archivo `.docx` con la información. En el futuro se usará una API para obtener las incidencias de manera automática.
 
-Para iniciar el análisis, seleccioná **Analizador de incidencias** en el menú principal o ejecutá `/analizar_incidencias`. Luego enviá el documento `.docx` y el bot responderá con los hallazgos.
+Para iniciar el análisis, seleccioná **Analizador de incidencias** en el menú principal o ejecutá `/analizar_incidencias`. Luego enviá el documento `.docx` y el bot responderá con los hallazgos. Además, recibirás un nuevo `.docx` con la cronología de eventos extraídos.
 
 ## Errores por variables de entorno faltantes
 

--- a/Sandy bot/sandybot/handlers/incidencias.py
+++ b/Sandy bot/sandybot/handlers/incidencias.py
@@ -87,11 +87,28 @@ async def procesar_incidencias(update: Update, context: ContextTypes.DEFAULT_TYP
         os.remove(ruta_docx)
 
     lineas = [f"{d.get('fecha')}: {d.get('evento')}" for d in datos]
-    respuesta = "Cronología de incidencias:\n" + "\n".join(lineas)
+
+    # Crear un documento Word con un párrafo por evento
+    doc_salida = Document()
+    for linea in lineas:
+        doc_salida.add_paragraph(linea)
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".docx") as tmp_out:
+        doc_salida.save(tmp_out.name)
+        ruta_salida = tmp_out.name
+
+    # Enviar el archivo .docx al usuario
+    try:
+        with open(ruta_salida, "rb") as f:
+            await mensaje.reply_document(f, filename="cronologia_incidencias.docx")
+    finally:
+        os.remove(ruta_salida)
+
+    # Registrar la conversación con un mensaje breve
     await responder_registrando(
         mensaje,
         user_id,
         documento.file_name,
-        respuesta,
+        "Adjunto la cronología de incidencias en formato .docx.",
         "incidencias",
     )


### PR DESCRIPTION
## Summary
- export "Analizar incidencias" result as DOCX
- document new DOCX output in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438437fef88330972c38b5469691b6