### PR TITLE
Agregar tests de incidencias con múltiples archivos

### DIFF
--- a/Sandy bot/sandybot/incidencias.py
+++ b/Sandy bot/sandybot/incidencias.py
@@ -1,4 +1,5 @@
 from docx import Document
+from pathlib import Path
 from .gpt_handler import gpt
 
 async def procesar_incidencias_docx(ruta: str) -> str:
@@ -6,3 +7,31 @@ async def procesar_incidencias_docx(ruta: str) -> str:
     doc = Document(ruta)
     texto = "\n".join(p.text for p in doc.paragraphs if p.text)
     return await gpt.consultar_gpt(texto)
+
+
+async def procesar_incidencias_archivos(rutas: list[str], contexto: str | None = None) -> str:
+    """Combina texto de varios archivos y lo envía a GPT.
+
+    Se aceptan paths a documentos ``.docx`` o ``.doc`` de texto plano. Si se
+    indica ``contexto`` se adjunta al final del mensaje.
+    """
+    textos: list[str] = []
+
+    for ruta in rutas:
+        path = Path(ruta)
+        if path.suffix.lower() == ".docx":
+            doc = Document(path)
+            textos.append("\n".join(p.text for p in doc.paragraphs if p.text))
+        else:
+            textos.append(path.read_text(encoding="utf-8"))
+
+    if contexto:
+        cpath = Path(contexto)
+        if cpath.suffix.lower() == ".docx":
+            doc = Document(cpath)
+            textos.append("\n".join(p.text for p in doc.paragraphs if p.text))
+        else:
+            textos.append(cpath.read_text(encoding="utf-8"))
+
+    mensaje = "\n".join(textos)
+    return await gpt.consultar_gpt(mensaje)

--- a/tests/test_incidencias.py
+++ b/tests/test_incidencias.py
@@ -76,3 +76,31 @@ def test_procesar_incidencias_docx(tmp_path):
     respuesta = asyncio.run(incidencias.procesar_incidencias_docx(str(doc_path)))
     assert respuesta == "ok"
     assert incidencias.gpt.last_msg == "Primera linea\nSegunda linea"
+
+
+def test_procesar_varios_archivos(tmp_path):
+    doc1 = tmp_path / "a.docx"
+    doc2 = tmp_path / "b.docx"
+    ctx = tmp_path / "extra.txt"
+
+    d1 = Document()
+    d1.add_paragraph("Linea A")
+    d1.save(doc1)
+
+    d2 = Document()
+    d2.add_paragraph("Linea B")
+    d2.save(doc2)
+
+    ctx.write_text("Contexto", encoding="utf-8")
+
+    respuesta = asyncio.run(
+        incidencias.procesar_incidencias_archivos(
+            [str(doc1), str(doc2)], str(ctx)
+        )
+    )
+
+    assert respuesta == "ok"
+    assert (
+        incidencias.gpt.last_msg
+        == "Linea A\nLinea B\nContexto"
+    )


### PR DESCRIPTION
## Summary
- añadir `procesar_incidencias_archivos` para unificar varios documentos
- cubrir casos de uso con múltiples archivos y contexto en tests

## Testing
- `pip install openpyxl pandas python-docx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843843efed48330a1cf2a882bfbe46f