### PR TITLE
Registrar ingresos a cámaras

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -64,6 +64,33 @@ class Servicio(Base):
         return f"<Servicio(id={self.id}, nombre={self.nombre}, cliente={self.cliente})>"
 
 
+class Camara(Base):
+    """Registro de cámaras asociadas a los servicios."""
+    __tablename__ = "camaras"
+
+    id = Column(Integer, primary_key=True)
+    nombre = Column(String, index=True)
+    id_servicio = Column(Integer, index=True)
+
+    def __repr__(self) -> str:
+        return f"<Camara(id={self.id}, nombre={self.nombre}, servicio={self.id_servicio})>"
+
+
+class Ingreso(Base):
+    """Almacena cada ingreso a una cámara con fecha y usuario."""
+    __tablename__ = "ingresos"
+
+    id = Column(Integer, primary_key=True)
+    id_servicio = Column(Integer, index=True)
+    id_camara = Column(Integer, index=True, nullable=True)
+    camara = Column(String, index=True)
+    fecha = Column(DateTime, default=datetime.utcnow, index=True)
+    usuario = Column(String)
+
+    def __repr__(self) -> str:
+        return f"<Ingreso(id={self.id}, camara={self.camara}, fecha={self.fecha})>"
+
+
 def ensure_servicio_columns() -> None:
     """Comprueba que la tabla ``servicios`` posea todas las columnas del modelo.
 
@@ -217,4 +244,36 @@ def registrar_servicio(id_servicio: int, id_carrier: str | None = None) -> Servi
         session.commit()
         session.refresh(nuevo)
         return nuevo
+
+
+def crear_camara(nombre: str, id_servicio: int) -> Camara:
+    """Crea una cámara asociada a un servicio."""
+    with SessionLocal() as session:
+        camara = Camara(nombre=nombre, id_servicio=id_servicio)
+        session.add(camara)
+        session.commit()
+        session.refresh(camara)
+        return camara
+
+
+def crear_ingreso(
+    id_servicio: int,
+    camara: str,
+    fecha: datetime | None = None,
+    usuario: str | None = None,
+    id_camara: int | None = None,
+) -> Ingreso:
+    """Registra un ingreso a una cámara."""
+    with SessionLocal() as session:
+        ingreso = Ingreso(
+            id_servicio=id_servicio,
+            camara=camara,
+            fecha=fecha or datetime.utcnow(),
+            usuario=usuario,
+            id_camara=id_camara,
+        )
+        session.add(ingreso)
+        session.commit()
+        session.refresh(ingreso)
+        return ingreso
 

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -7,6 +7,7 @@ from .message import message_handler
 from .document import document_handler
 from .voice import voice_handler
 from .ingresos import iniciar_verificacion_ingresos, procesar_ingresos
+from .registro_ingresos import iniciar_registro_ingresos, guardar_registro
 from .repetitividad import procesar_repetitividad
 from .comparador import iniciar_comparador, recibir_tracking, procesar_comparacion
 from .cargar_tracking import iniciar_carga_tracking, guardar_tracking_servicio
@@ -23,6 +24,8 @@ __all__ = [
     'voice_handler',
     'iniciar_verificacion_ingresos',
     'procesar_ingresos',
+    'iniciar_registro_ingresos',
+    'guardar_registro',
     'procesar_repetitividad',
     'iniciar_comparador',
     'recibir_tracking',

--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -28,6 +28,11 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         registrar_conversacion(query.from_user.id, "boton_verificar_ingresos", "Inicio ingresos", "callback")
         await iniciar_verificacion_ingresos(update, context)
 
+    elif query.data == "registro_ingresos":
+        from .registro_ingresos import iniciar_registro_ingresos
+        registrar_conversacion(query.from_user.id, "registro_ingresos", "Inicio registro", "callback")
+        await iniciar_registro_ingresos(update, context)
+
     elif query.data == "ingresos_nombre":
         registrar_conversacion(query.from_user.id, "ingresos_nombre", "Elegir por nombre", "callback")
         from .ingresos import opcion_por_nombre

--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -124,6 +124,11 @@ async def message_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 )
                 return
 
+        if mode == "registro_ingresos":
+            from .registro_ingresos import guardar_registro
+            await guardar_registro(update, context)
+            return
+
         # Activar modo Sandy si no está activo␊
         if not mode:
             UserState.set_mode(user_id, "sandy")

--- a/Sandy bot/sandybot/handlers/registro_ingresos.py
+++ b/Sandy bot/sandybot/handlers/registro_ingresos.py
@@ -1,0 +1,93 @@
+"""Flujo para registrar ingresos a cámaras"""
+from datetime import datetime
+from telegram import Update
+from telegram.ext import ContextTypes
+from .estado import UserState
+from ..registrador import responder_registrando
+from ..database import crear_ingreso
+
+async def iniciar_registro_ingresos(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Inicia la carga solicitando ID de servicio."""
+    mensaje = update.callback_query.message if update.callback_query else update.message
+    user_id = update.effective_user.id
+    UserState.set_mode(user_id, "registro_ingresos")
+    context.user_data.clear()
+    await responder_registrando(
+        mensaje,
+        user_id,
+        "registro_ingresos",
+        "Ingresá el ID del servicio al que pertenece la cámara.",
+        "registro_ingresos",
+    )
+
+async def guardar_registro(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Guarda el ingreso paso a paso."""
+    mensaje = update.message
+    user_id = mensaje.from_user.id
+
+    if "id_servicio" not in context.user_data:
+        if mensaje.text and mensaje.text.isdigit():
+            context.user_data["id_servicio"] = int(mensaje.text)
+            await responder_registrando(
+                mensaje,
+                user_id,
+                mensaje.text,
+                "Escribí el nombre de la cámara.",
+                "registro_ingresos",
+            )
+        else:
+            await responder_registrando(
+                mensaje,
+                user_id,
+                mensaje.text or "",
+                "Indicá un ID numérico de servicio.",
+                "registro_ingresos",
+            )
+        return
+
+    if "camara" not in context.user_data:
+        context.user_data["camara"] = mensaje.text.strip()
+        await responder_registrando(
+            mensaje,
+            user_id,
+            mensaje.text,
+            "Indicá la hora en formato HH:MM o la fecha completa AAAA-MM-DD HH:MM.",
+            "registro_ingresos",
+        )
+        return
+
+    if "fecha" not in context.user_data:
+        texto = mensaje.text.strip()
+        try:
+            if " " in texto:
+                fecha = datetime.strptime(texto, "%Y-%m-%d %H:%M")
+            else:
+                hoy = datetime.now().strftime("%Y-%m-%d")
+                fecha = datetime.strptime(f"{hoy} {texto}", "%Y-%m-%d %H:%M")
+        except ValueError:
+            await responder_registrando(
+                mensaje,
+                user_id,
+                mensaje.text,
+                "Formato inválido. Usá HH:MM o AAAA-MM-DD HH:MM.",
+                "registro_ingresos",
+            )
+            return
+
+        context.user_data["fecha"] = fecha
+        crear_ingreso(
+            id_servicio=context.user_data["id_servicio"],
+            camara=context.user_data["camara"],
+            fecha=fecha,
+            usuario=str(user_id),
+        )
+        UserState.set_mode(user_id, "")
+        context.user_data.clear()
+        await responder_registrando(
+            mensaje,
+            user_id,
+            mensaje.text,
+            "Ingreso registrado correctamente.",
+            "registro_ingresos",
+        )
+        return

--- a/Sandy bot/sandybot/handlers/start.py
+++ b/Sandy bot/sandybot/handlers/start.py
@@ -11,6 +11,7 @@ async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         [
            InlineKeyboardButton("📊 Comparar trazados FO", callback_data="comparar_fo"),
            InlineKeyboardButton("📥 Verificar ingresos", callback_data="verificar_ingresos"),
+           InlineKeyboardButton("📌 Registro de ingresos", callback_data="registro_ingresos"),
         ],
         [
            InlineKeyboardButton("📂 Cargar tracking", callback_data="cargar_tracking"),

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2,6 +2,7 @@ import os
 import sys
 import importlib
 from pathlib import Path
+from datetime import datetime
 import pytest
 import openpyxl
 
@@ -65,3 +66,13 @@ def test_exportar_camaras_servicio(tmp_path):
     ws = wb.active
     filas = [c[0].value for c in ws.iter_rows(values_only=False)]
     assert filas == ["camara", "Camara 1", "Camara 2"]
+
+
+def test_crear_ingreso():
+    servicio = bd.crear_servicio(nombre="S5", cliente="E")
+    fecha = datetime(2023, 1, 1, 12, 30)
+    ingreso = bd.crear_ingreso(servicio.id, "Camara X", fecha=fecha, usuario="u")
+    with bd.SessionLocal() as session:
+        fila = session.query(bd.Ingreso).first()
+        assert fila.camara == "Camara X"
+        assert fila.fecha == fecha


### PR DESCRIPTION
## Summary
- registrar horarios de ingreso a cada cámara en la base de datos
- añadir flujo *Registro de ingresos* en el menú y sus callbacks
- manejar el nuevo modo en los mensajes
- tests de base de datos ajustados

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437dec7de08330aa827c329b89a238