### PR TITLE
Implementar búsqueda sin acentos en SQL

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -41,7 +41,7 @@ bd.Base.metadata.create_all(bind=bd.engine)
 
 
 def test_buscar_servicios_por_camara():
-    bd.crear_servicio(nombre="S1", cliente="A", camaras=["Camara Central"])
+    bd.crear_servicio(nombre="S1", cliente="A", camaras=["Cámara Central"])
     bd.crear_servicio(nombre="S2", cliente="B", camaras=["Nodo Secundario"])
     bd.crear_servicio(nombre="S3", cliente="C", camaras=["Avenida General San Martin"])
 
@@ -55,10 +55,13 @@ def test_buscar_servicios_por_camara():
     camara = "Cra Av. Gral Juan Domingo Per\u00f3n 7540 BENAVIDEZ"
     bd.crear_servicio(nombre="S4", cliente="D", camaras=[camara])
 
-    # La búsqueda utiliza la misma cadena que se almacen\u00f3. Con la mejora,
-    # debe encontrarse el servicio sin importar las diferencias de formato
-    res3 = bd.buscar_servicios_por_camara(camara)
+    # La búsqueda debería funcionar aunque se omitan los acentos
+    res3 = bd.buscar_servicios_por_camara("peron 7540")
     assert {s.nombre for s in res3} == {"S4"}
+
+    bd.crear_servicio(nombre="S5", cliente="E", camaras=["Cámara Fiscalía"])
+    res4 = bd.buscar_servicios_por_camara("camara fiscalia")
+    assert {s.nombre for s in res4} == {"S5"}
 
 
 def test_exportar_camaras_servicio(tmp_path):


### PR DESCRIPTION
## Summary
- crear índice GIN utilizando `unaccent` cuando la base es PostgreSQL
- agregar búsqueda de cámaras sin acentos en la consulta SQL
- mejorar test para cubrir la nueva lógica con diferencias de acentos

## Testing
- `pip install -q openpyxl pandas python-docx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684746339abc8330bf13e5d74b055610