### PR TITLE
Fix tipo correcto en columnas faltantes

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -103,8 +103,11 @@ def ensure_servicio_columns() -> None:
 
     faltantes = definidas - actuales
     for columna in faltantes:
+        tipo = Servicio.__table__.columns[columna].type.compile(engine.dialect)
         with engine.begin() as conn:
-            conn.execute(text(f"ALTER TABLE servicios ADD COLUMN {columna} VARCHAR"))
+            conn.execute(
+                text(f"ALTER TABLE servicios ADD COLUMN {columna} {tipo}")
+            )
 
 def init_db():
     """Inicializa la base de datos y crea las tablas si no existen."""

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -7,7 +7,7 @@ import pytest
 import openpyxl
 
 sqlalchemy = pytest.importorskip("sqlalchemy")
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 # Agregar ruta del paquete
@@ -85,3 +85,25 @@ def test_crear_ingreso():
         fila = session.query(bd.Ingreso).first()
         assert fila.camara == "Camara X"
         assert fila.fecha == fecha
+
+
+def test_ensure_servicio_columns_crea_tipos_correctos():
+    """Verifica que las columnas faltantes se creen con su tipo real."""
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE servicios (id INTEGER PRIMARY KEY)"))
+
+    bd.engine = engine
+    bd.SessionLocal = sessionmaker(bind=engine)
+    bd.ensure_servicio_columns()
+
+    inspector = sqlalchemy.inspect(engine)
+    columnas = {
+        c["name"]: c["type"].compile(engine.dialect)
+        for c in inspector.get_columns("servicios")
+    }
+    esperados = {
+        col.name: col.type.compile(engine.dialect)
+        for col in bd.Servicio.__table__.columns
+    }
+    assert columnas == esperados


### PR DESCRIPTION
## Cambios
- se actualiza `ensure_servicio_columns` para tomar el tipo real de cada columna y usarlo en el `ALTER TABLE`
- se añade prueba unitaria que verifica la creación de columnas con su tipo correcto cuando faltan en la tabla

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474641838c83309130453940918498