### PR TITLE
Evitar expiración de instancias al cerrar la sesión

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -26,7 +26,9 @@ engine = create_engine(
 )
 
 # Crear sessionmaker
-SessionLocal = sessionmaker(bind=engine)
+# ``expire_on_commit=False`` evita que los objetos devueltos pierdan sus datos
+# al cerrarse la sesión, algo útil cuando las funciones retornan instancias.
+SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
 
 # Base declarativa para los modelos
 Base = declarative_base()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -36,7 +36,7 @@ sqlalchemy.create_engine = lambda *a, **k: orig_create_engine("sqlite:///:memory
 bd = importlib.import_module("sandybot.database")
 
 sqlalchemy.create_engine = orig_create_engine
-bd.SessionLocal = sessionmaker(bind=bd.engine)
+bd.SessionLocal = sessionmaker(bind=bd.engine, expire_on_commit=False)
 bd.Base.metadata.create_all(bind=bd.engine)
 
 


### PR DESCRIPTION
## Summary
- ajusta la creación de `SessionLocal` para que no expire los objetos tras hacer commit
- actualiza la prueba que modifica la sesión

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474650b64c8330a81b37255b6313d0