### PR TITLE
Actualizar registrar_servicio con merge

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -231,27 +231,22 @@ def exportar_camaras_servicio(id_servicio: int, ruta_excel: str) -> bool:
 
 
 def registrar_servicio(id_servicio: int, id_carrier: str | None = None) -> Servicio:
-    """Crea o actualiza un servicio con el ``id_servicio`` dado.
+    """Inserta o actualiza un servicio utilizando ``session.merge``.
 
-    Si el servicio existe, se actualiza el campo ``id_carrier`` si fue
-    proporcionado. En caso contrario se genera un nuevo registro con los datos
-    recibidos.
+    Se crea un objeto :class:`Servicio` con el ID indicado y, si se
+    proporciona ``id_carrier``, también se asigna. ``merge`` evita duplicados
+    al combinarlo con la fila existente cuando corresponde.
     """
     with SessionLocal() as session:
-        servicio = session.get(Servicio, id_servicio)
-        if servicio:
-            if id_carrier is not None:
-                servicio.id_carrier = str(id_carrier)
-            session.commit()
-            session.refresh(servicio)
-            return servicio
-        nuevo = Servicio(id=id_servicio)
+        datos = {"id": id_servicio}
         if id_carrier is not None:
-            nuevo.id_carrier = str(id_carrier)
-        session.add(nuevo)
+            datos["id_carrier"] = str(id_carrier)
+
+        servicio = Servicio(**datos)
+        servicio = session.merge(servicio)
         session.commit()
-        session.refresh(nuevo)
-        return nuevo
+        session.refresh(servicio)
+        return servicio
 
 
 def crear_camara(nombre: str, id_servicio: int) -> Camara:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -14,6 +14,28 @@ from sqlalchemy.orm import sessionmaker
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
+# Crear stub del módulo telegram para las utilidades
+telegram_stub = importlib.util.module_from_spec(importlib.machinery.ModuleSpec("telegram", None))
+class Message:
+    def __init__(self, text=""):
+        self.text = text
+class CallbackQuery:
+    def __init__(self, message=None):
+        self.message = message
+class Update:
+    def __init__(self, message=None, edited_message=None, callback_query=None):
+        self.message = message
+        self.edited_message = edited_message
+        self.callback_query = callback_query
+telegram_stub.Update = Update
+telegram_stub.Message = Message
+sys.modules.setdefault("telegram", telegram_stub)
+
+# Stub de dotenv requerido por config
+dotenv_stub = importlib.util.module_from_spec(importlib.machinery.ModuleSpec("dotenv", None))
+dotenv_stub.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+
 # Variables de entorno necesarias para Config
 required_vars = {
     "TELEGRAM_TOKEN": "x",
@@ -85,3 +107,14 @@ def test_crear_ingreso():
         fila = session.query(bd.Ingreso).first()
         assert fila.camara == "Camara X"
         assert fila.fecha == fecha
+
+
+def test_registrar_servicio_merge():
+    """Verifica que ``registrar_servicio`` no duplique filas."""
+    bd.crear_servicio(id=100, nombre="n1", cliente="a")
+    bd.registrar_servicio(100, "c1")
+    bd.registrar_servicio(100, "c1")
+    with bd.SessionLocal() as session:
+        filas = session.query(bd.Servicio).filter(bd.Servicio.id == 100).all()
+        assert len(filas) == 1
+        assert filas[0].id_carrier == "c1"


### PR DESCRIPTION
## Resumen
- usar `session.merge` al registrar un servicio
- stubear dependencias faltantes en las pruebas
- comprobar que no se creen filas duplicadas

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847465f541c833084a25ffde02def11