### PR TITLE
Fix GIN index for JSONB camaras

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -134,7 +134,8 @@ def init_db():
             conn.execute(
                 text(
                     "CREATE INDEX IF NOT EXISTS ix_servicios_camaras_unaccent "
-                    "ON servicios USING gin ((unaccent(lower(camaras))) gin_trgm_ops)"
+                    "ON servicios USING gin (" 
+                    "unaccent(lower(camaras::text)) gin_trgm_ops)"
                 )
             )
 


### PR DESCRIPTION
## Summary
- cast `camaras` to text when creating the GIN index
- keep `unaccent` + `pg_trgm` ops for case-insensitive search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474d43cf4c8330bdcddaa97449ce34