### PR TITLE
Fix JSONB import for PostgreSQL

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -5,7 +5,7 @@ Configuración y modelos de la base de datos
 
 from sqlalchemy import create_engine, Column, Integer, String, DateTime, text, inspect, func
 from sqlalchemy.orm import declarative_base, sessionmaker
-from sqlalchemy import JSON as JSONB
+from sqlalchemy.dialects.postgresql import JSONB
 import json
 import pandas as pd
 from .utils import normalizar_camara


### PR DESCRIPTION
## Summary
- usar JSONB del dialecto PostgreSQL
- mantener columnas `trackings` y `camaras` con JSONB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847515cc5148330b6ecd678d1a85214