### PR TITLE
Soporte para trackings heredados

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -182,6 +182,15 @@ def actualizar_tracking(
             servicio.camaras = camaras
         if trackings_txt:
             existentes = servicio.trackings or []
+            # Compatibilidad con registros del esquema antiguo. Si ``existentes``
+            # es una cadena (antes se almacenaba como texto) intentamos
+            # convertirlo desde JSON. Si falla o está vacío, se utiliza una
+            # lista vacía.
+            if isinstance(existentes, str):
+                try:
+                    existentes = json.loads(existentes) if existentes else []
+                except json.JSONDecodeError:
+                    existentes = []
             existentes.extend(trackings_txt)
             servicio.trackings = existentes
         session.commit()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -116,6 +116,16 @@ def test_actualizar_tracking_jsonb():
         assert reg.trackings == ["t1.txt"]
 
 
+def test_actualizar_tracking_string():
+    """Verifica que se actualice si el campo ``trackings`` quedó como texto."""
+    servicio = bd.crear_servicio(nombre="S7", cliente="G", trackings="[]")
+    bd.actualizar_tracking(servicio.id, trackings_txt=["nuevo.txt"])
+
+    with bd.SessionLocal() as s:
+        reg = s.get(bd.Servicio, servicio.id)
+        assert reg.trackings == ["nuevo.txt"]
+
+
 def test_crear_ingreso():
     servicio = bd.crear_servicio(nombre="S5", cliente="E")
     fecha = datetime(2023, 1, 1, 12, 30)


### PR DESCRIPTION
## Summary
- manejar casos en que `servicio.trackings` es texto heredado
- añadir prueba que cubra ese escenario

## Testing
- `pip install pandas openpyxl python-docx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684751921ecc8330ae3bf2f6e832132c