### PR TITLE
Fix trailing spaces in tracking_parser

### DIFF
--- a/Sandy bot/sandybot/tracking_parser.py
+++ b/Sandy bot/sandybot/tracking_parser.py
@@ -70,4 +70,3 @@ class TrackingParser:
             for sheet, df in self._data:
                 df.to_excel(writer, sheet_name=sheet, index=False)
             coincidencias.to_excel(writer, sheet_name="Coincidencias", index=False)
-            


### PR DESCRIPTION
## Summary
- remove stray blank line in `tracking_parser.py`
- ensure file ends with newline

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684757790a9c8330bf04452879203413