### PR TITLE
Añade nota sobre textract en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,24 @@ en caso contrario.
 
 ## Analizador de incidencias
 
-Esta función genera un resumen de las fallas registradas en reportes de campo. Ahora acepta archivos `.docx` y `.doc`, incluso varios adjuntos al mismo tiempo. Entre ellos se puede incluir un archivo de contexto o correos electrónicos. En el futuro se usará una API para obtener las incidencias de manera automática.
+Esta función genera un resumen de las fallas registradas en reportes de campo. Ahora acepta archivos `.docx` y `.doc`, incluso varios adjuntos al mismo tiempo. Entre ellos se puede incluir un archivo de contexto o correos electrónicos. En el futuro se usará una API para obtener las incidencias de manera automática. Para leer documentos con extensión `.doc` se debe instalar el paquete `textract` de forma opcional.
 
 
 Para iniciar el análisis, seleccioná **Analizador de incidencias** en el menú principal o ejecutá `/analizar_incidencias`. Luego enviá el documento `.docx` y el bot responderá con los hallazgos. Además, recibirás un nuevo `.docx` con la cronología de eventos extraídos.
+
+### Habilitar lectura de `.doc`
+
+Si necesitás procesar documentos con extensión `.doc`, instalá el paquete opcional `textract`:
+
+```bash
+pip install textract
+```
+
+También podés incluirlo al instalar todas las dependencias:
+
+```bash
+pip install -r requirements.txt
+```
 
 
 ## Errores por variables de entorno faltantes

--- a/Sandy bot/requirements.txt
+++ b/Sandy bot/requirements.txt
@@ -11,3 +11,4 @@ python-Levenshtein>=0.12.0
 pywin32>=300; sys_platform == 'win32'
 jsonschema>=4.0.0
 SQLAlchemy>=1.4
+textract>=1.0  # opcional para archivos .doc


### PR DESCRIPTION
## Summary
- explica que los archivos .doc necesitan `textract`
- documenta cómo instalarlo
- declara `textract` como dependencia opcional

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847577a9a688330b4ee6f01fc2622b9