### PR TITLE
Aclaraciones sobre archivos DOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,13 @@ en caso contrario.
 
 ## Analizador de incidencias
 
-Esta función genera un resumen de las fallas registradas en reportes de campo. Ahora acepta archivos `.docx` y `.doc`, incluso varios adjuntos al mismo tiempo. Entre ellos se puede incluir un archivo de contexto o correos electrónicos. En el futuro se usará una API para obtener las incidencias de manera automática.
+Esta función genera un resumen de las fallas registradas en reportes de campo. Ahora acepta archivos `.docx` y `.doc`, incluso varios adjuntos al mismo tiempo. Para procesar documentos `.doc` se debe instalar la biblioteca `textract`.
 
+```bash
+pip install textract
+```
+
+Entre los adjuntos se puede incluir un archivo de contexto o correos electrónicos. En el futuro se usará una API para obtener las incidencias de manera automática.
 
 Para iniciar el análisis, seleccioná **Analizador de incidencias** en el menú principal o ejecutá `/analizar_incidencias`. Luego enviá el documento `.docx` y el bot responderá con los hallazgos. Además, recibirás un nuevo `.docx` con la cronología de eventos extraídos.
 

--- a/Sandy bot/requirements.txt
+++ b/Sandy bot/requirements.txt
@@ -11,3 +11,4 @@ python-Levenshtein>=0.12.0
 pywin32>=300; sys_platform == 'win32'
 jsonschema>=4.0.0
 SQLAlchemy>=1.4
+textract>=1.0.0  # opcional para archivos .doc


### PR DESCRIPTION
## Summary
- destacar que para procesar archivos `.doc` es necesario instalar `textract`
- agregar `textract` como dependencia opcional

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475a3f4d588330ba0df02a9e81126e