### PR TITLE
Añade configuración de Slack y base supervisor

### DIFF
--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -1,5 +1,10 @@
-"""
-Configuración centralizada para el bot Sandy
+"""Configuración centralizada para el bot Sandy.
+
+Este módulo concentra la lectura de todas las variables de entorno
+necesarias para ejecutar el bot. A partir de aquí se definen rutas de
+trabajo, claves de acceso a APIs y parámetros de conexión.  De esta
+forma el resto del código sólo importa :class:`Config` y no debe
+preocuparse por dónde provienen esos valores.
 """
 import os
 import logging
@@ -8,7 +13,14 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 class Config:
-    """Clase singleton para manejar la configuración global"""
+    """Clase singleton para manejar la configuración global.
+
+    Al instanciarla se cargan las variables de entorno indispensables
+    para el funcionamiento del bot.  Además de las claves de Telegram,
+    OpenAI y Notion se añaden ``SLACK_WEBHOOK_URL`` y ``SUPERVISOR_DB_ID``
+    que permiten enviar alertas a Slack y registrar acciones en una
+    base de Notion destinada al modo supervisor.
+    """
     _instance = None
 
     def __new__(cls):
@@ -41,6 +53,10 @@ class Config:
         self.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
         self.NOTION_TOKEN = os.getenv("NOTION_TOKEN")
         self.NOTION_DATABASE_ID = os.getenv("NOTION_DATABASE_ID")
+        # URL del webhook para enviar notificaciones a Slack
+        self.SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+        # ID de la base de Notion utilizada en el modo supervisor
+        self.SUPERVISOR_DB_ID = os.getenv("SUPERVISOR_DB_ID")
         
         # Archivos y rutas
         self.ARCHIVO_CONTADOR = self.DATA_DIR / "contador_diario.json"
@@ -89,6 +105,8 @@ class Config:
             "OPENAI_API_KEY": self.OPENAI_API_KEY,
             "NOTION_TOKEN": self.NOTION_TOKEN,
             "NOTION_DATABASE_ID": self.NOTION_DATABASE_ID,
+            "SLACK_WEBHOOK_URL": self.SLACK_WEBHOOK_URL,
+            "SUPERVISOR_DB_ID": self.SUPERVISOR_DB_ID,
             "DB_USER": self.DB_USER,
             "DB_PASSWORD": self.DB_PASSWORD
         }

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -44,6 +44,8 @@ required_vars = {
     "NOTION_DATABASE_ID": "x",
     "DB_USER": "user",
     "DB_PASSWORD": "pass",
+    "SLACK_WEBHOOK_URL": "x",
+    "SUPERVISOR_DB_ID": "x",
     "DB_HOST": "localhost",
     "DB_PORT": "5432",
     "DB_NAME": "sandy",

--- a/tests/test_gpt_cache.py
+++ b/tests/test_gpt_cache.py
@@ -47,6 +47,8 @@ os.environ.setdefault("NOTION_TOKEN", "x")
 os.environ.setdefault("NOTION_DATABASE_ID", "x")
 os.environ.setdefault("DB_USER", "x")
 os.environ.setdefault("DB_PASSWORD", "x")
+os.environ.setdefault("SLACK_WEBHOOK_URL", "x")
+os.environ.setdefault("SUPERVISOR_DB_ID", "x")
 
 # Importar módulos de SandyBot
 config_mod = importlib.import_module("sandybot.config")

--- a/tests/test_incidencias.py
+++ b/tests/test_incidencias.py
@@ -48,7 +48,16 @@ sys.modules.setdefault("jsonschema", jsonschema_stub)
 
 # Variables de entorno mínimas para Config
 import os
-for var in ["TELEGRAM_TOKEN", "OPENAI_API_KEY", "NOTION_TOKEN", "NOTION_DATABASE_ID", "DB_USER", "DB_PASSWORD"]:
+for var in [
+    "TELEGRAM_TOKEN",
+    "OPENAI_API_KEY",
+    "NOTION_TOKEN",
+    "NOTION_DATABASE_ID",
+    "DB_USER",
+    "DB_PASSWORD",
+    "SLACK_WEBHOOK_URL",
+    "SUPERVISOR_DB_ID",
+]:
     os.environ.setdefault(var, "x")
 
 # Importar módulos de SandyBot

--- a/tests/test_userstate.py
+++ b/tests/test_userstate.py
@@ -113,7 +113,16 @@ registrador_stub.responder_registrando = responder_registrando
 sys.modules.setdefault("sandybot.registrador", registrador_stub)
 
 # Variables requeridas por Config
-for var in ["TELEGRAM_TOKEN", "OPENAI_API_KEY", "NOTION_TOKEN", "NOTION_DATABASE_ID", "DB_USER", "DB_PASSWORD"]:
+for var in [
+    "TELEGRAM_TOKEN",
+    "OPENAI_API_KEY",
+    "NOTION_TOKEN",
+    "NOTION_DATABASE_ID",
+    "DB_USER",
+    "DB_PASSWORD",
+    "SLACK_WEBHOOK_URL",
+    "SUPERVISOR_DB_ID",
+]:
     os.environ.setdefault(var, "x")
 
 # Importar config despues de establecer las variables


### PR DESCRIPTION
## Resumen
- añade docstring expandido en `config.py`
- incorpora variables `SLACK_WEBHOOK_URL` y `SUPERVISOR_DB_ID`
- valida las nuevas variables en `Config.validate`
- adapta los tests para incluirlas

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68475fbde1148330a8f089e303511908