### PR TITLE
Añade utilitario para enviar correos

### DIFF
--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -73,6 +73,13 @@ class Config:
         self.DB_NAME = os.getenv("DB_NAME", "sandybot")
         self.DB_USER = os.getenv("DB_USER")
         self.DB_PASSWORD = os.getenv("DB_PASSWORD")
+
+        # Credenciales de correo electrónico
+        self.EMAIL_HOST = os.getenv("EMAIL_HOST", "smtp.gmail.com")
+        self.EMAIL_PORT = int(os.getenv("EMAIL_PORT", "465"))
+        self.EMAIL_USER = os.getenv("EMAIL_USER")
+        self.EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
+        self.EMAIL_FROM = os.getenv("EMAIL_FROM")
         
         # Validación
         self.validate()
@@ -102,6 +109,18 @@ class Config:
             )
             logging.error(mensaje)
             raise ValueError(mensaje)
+
+        # Advertir si faltan datos de correo
+        email_missing = [
+            nombre
+            for nombre in ["EMAIL_USER", "EMAIL_PASSWORD", "EMAIL_FROM"]
+            if not getattr(self, nombre)
+        ]
+        if email_missing:
+            logging.warning(
+                "Variables de correo no definidas: %s",
+                ", ".join(email_missing),
+            )
 
 # Instancia global
 config = Config()

--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -1,0 +1,59 @@
+"""Funciones para el envío de correos electrónicos"""
+
+import logging
+import smtplib
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Iterable, Optional
+
+from .config import config
+
+logger = logging.getLogger(__name__)
+
+
+def enviar_email(
+    destinatarios: Iterable[str],
+    asunto: str,
+    cuerpo: str,
+    adjuntos: Optional[Iterable[str]] = None,
+) -> bool:
+    """Envía un correo utilizando las credenciales definidas en ``config``.
+
+    Si falta alguna credencial obligatoria se registra un error y se
+    devuelve ``False``.
+    """
+
+    if not (config.EMAIL_USER and config.EMAIL_PASSWORD and config.EMAIL_FROM):
+        logger.error("Credenciales de correo incompletas")
+        return False
+
+    mensaje = EmailMessage()
+    mensaje["From"] = config.EMAIL_FROM
+    mensaje["To"] = ", ".join(destinatarios)
+    mensaje["Subject"] = asunto
+    mensaje.set_content(cuerpo)
+
+    if adjuntos:
+        for archivo in adjuntos:
+            try:
+                path = Path(archivo)
+                with open(path, "rb") as f:
+                    datos = f.read()
+                mensaje.add_attachment(
+                    datos,
+                    maintype="application",
+                    subtype="octet-stream",
+                    filename=path.name,
+                )
+            except Exception as e:
+                logger.error("Error al adjuntar %s: %s", archivo, e)
+
+    try:
+        with smtplib.SMTP_SSL(config.EMAIL_HOST, config.EMAIL_PORT) as smtp:
+            smtp.login(config.EMAIL_USER, config.EMAIL_PASSWORD)
+            smtp.send_message(mensaje)
+        logger.info("\ud83d\udce7 Correo enviado a %s", mensaje["To"])
+        return True
+    except Exception as e:
+        logger.error("Error al enviar correo: %s", e)
+        return False


### PR DESCRIPTION
## Notas
- Se agregaron variables de entorno para SMTP en `config.py`.
- Nuevo módulo `email_utils.py` con la función `enviar_email` que permite adjuntar archivos y reporta errores.
- Se actualizó la validación para advertir cuando faltan credenciales de correo.
- Todas las pruebas continúan pasando.


------
https://chatgpt.com/codex/tasks/task_e_68475fc937f883308b1622804edde7b5