### PR TITLE
Añadir utilidades para destinatarios

### DIFF
--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -46,6 +46,8 @@ class Config:
         self.ARCHIVO_CONTADOR = self.DATA_DIR / "contador_diario.json"
         # Registro histórico de interacciones por usuario
         self.ARCHIVO_INTERACCIONES = self.DATA_DIR / "interacciones.json"
+        # Lista de destinatarios de notificaciones
+        self.ARCHIVO_DESTINATARIOS = self.DATA_DIR / "destinatarios.json"
         self.LOG_FILE = self.LOG_DIR / "sandy.log"
         self.ERRORES_FILE = self.LOG_DIR / "errores_ingresos.log"
         # Cache de consultas a GPT para reducir costos y latencia

--- a/Sandy bot/sandybot/utils.py
+++ b/Sandy bot/sandybot/utils.py
@@ -90,3 +90,16 @@ def obtener_mensaje(update: Update) -> Optional[Message]:
     if update.callback_query and update.callback_query.message:
         return update.callback_query.message
     return None
+
+def cargar_destinatarios() -> Dict[str, Any]:
+    """Carga el archivo de destinatarios definido en :class:`Config`."""
+    from .config import config
+
+    return cargar_json(config.ARCHIVO_DESTINATARIOS)
+
+
+def guardar_destinatarios(destinatarios: Dict[str, Any]) -> bool:
+    """Guarda la lista de destinatarios en el archivo configurado."""
+    from .config import config
+
+    return guardar_json(destinatarios, config.ARCHIVO_DESTINATARIOS)


### PR DESCRIPTION
## Summary
- agregar ruta `ARCHIVO_DESTINATARIOS` en `Config`
- crear funciones `cargar_destinatarios` y `guardar_destinatarios`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475fd11b748330bd04d4dcfebd50fe