### PR TITLE
Añadir envío de Excel por correo

### DIFF
--- a/Sandy bot/data/destinatarios.json
+++ b/Sandy bot/data/destinatarios.json
@@ -1,0 +1,1 @@
+{"emails": ["ejemplo@correo.com"]}

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -73,6 +73,19 @@ class Config:
         self.DB_NAME = os.getenv("DB_NAME", "sandybot")
         self.DB_USER = os.getenv("DB_USER")
         self.DB_PASSWORD = os.getenv("DB_PASSWORD")
+
+        # Opciones para el envío de correos. No son obligatorias, por lo que
+        # se cargan sin validar para mantener compatibilidad con entornos
+        # que no utilizan esta característica.
+        self.SMTP_HOST = os.getenv("SMTP_HOST")
+        self.SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
+        self.SMTP_USER = os.getenv("SMTP_USER")
+        self.SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
+        self.EMAIL_FROM = os.getenv("EMAIL_FROM")
+
+        # Ruta del archivo que almacena los destinatarios para los envíos
+        # automáticos de reportes o listados.
+        self.DESTINATARIOS_FILE = self.DATA_DIR / "destinatarios.json"
         
         # Validación
         self.validate()

--- a/Sandy bot/sandybot/correo.py
+++ b/Sandy bot/sandybot/correo.py
@@ -1,0 +1,58 @@
+import os
+import smtplib
+from email.message import EmailMessage
+import logging
+from .config import config
+
+logger = logging.getLogger(__name__)
+
+
+def enviar_email(destinatarios, asunto, cuerpo, archivo_adjunto):
+    """Envía un correo con un adjunto.
+
+    Parameters
+    ----------
+    destinatarios : list[str]
+        Lista de direcciones de correo.
+    asunto : str
+        Asunto del mensaje.
+    cuerpo : str
+        Texto del correo.
+    archivo_adjunto : str
+        Ruta al archivo a adjuntar.
+
+    Returns
+    -------
+    bool
+        ``True`` si el envío fue exitoso.
+    """
+    if not config.SMTP_HOST or not config.EMAIL_FROM:
+        logger.error("Configuración SMTP incompleta")
+        return False
+
+    msg = EmailMessage()
+    msg["Subject"] = asunto
+    msg["From"] = config.EMAIL_FROM
+    msg["To"] = ", ".join(destinatarios)
+    msg.set_content(cuerpo)
+
+    try:
+        with open(archivo_adjunto, "rb") as f:
+            datos = f.read()
+            nombre = os.path.basename(archivo_adjunto)
+        msg.add_attachment(datos, maintype="application", subtype="octet-stream", filename=nombre)
+    except Exception as e:
+        logger.error("No se pudo adjuntar el archivo: %s", e)
+        return False
+
+    try:
+        with smtplib.SMTP(config.SMTP_HOST, config.SMTP_PORT) as server:
+            server.starttls()
+            if config.SMTP_USER and config.SMTP_PASSWORD:
+                server.login(config.SMTP_USER, config.SMTP_PASSWORD)
+            server.send_message(msg)
+        logger.info("Correo enviado a %s", destinatarios)
+        return True
+    except Exception as e:
+        logger.error("Error enviando correo: %s", e)
+        return False

--- a/Sandy bot/sandybot/registrador.py
+++ b/Sandy bot/sandybot/registrador.py
@@ -43,3 +43,10 @@ async def responder_registrando(
     """Envía una respuesta y registra la interacción."""
     await mensaje_obj.reply_text(texto_respuesta, **kwargs)
     registrar_conversacion(user_id, texto_usuario, texto_respuesta, modo)
+
+
+def registrar_envio_email(user_id: int, destinatarios: list[str], archivo: str) -> None:
+    """Registra en la base que se envió un correo con un adjunto."""
+    mensaje = f"Email a {', '.join(destinatarios)}"
+    respuesta = f"Archivo {archivo} enviado por email"
+    registrar_conversacion(user_id, mensaje, respuesta, "email")


### PR DESCRIPTION
## Summary
- habilitar configuración SMTP y archivo de destinatarios
- nuevo módulo `correo.py` con función `enviar_email`
- registrar envíos de correos en `registrador.py`
- permitir envío por email del Excel generado en `descargar_camaras`
- ejemplo de `destinatarios.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475fec7f2483308703ea574abf066b