### PR TITLE
Agregar envío de cámaras por mail

### DIFF
--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -24,7 +24,8 @@ from .handlers import (
     iniciar_comparador,
     procesar_comparacion,
     iniciar_carga_tracking,
-    iniciar_descarga_tracking
+    iniciar_descarga_tracking,
+    iniciar_envio_camaras_mail
 )
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,7 @@ class SandyBot:
         self.app.add_handler(CommandHandler("procesar", procesar_comparacion))
         self.app.add_handler(CommandHandler("cargar_tracking", iniciar_carga_tracking))
         self.app.add_handler(CommandHandler("descargar_tracking", iniciar_descarga_tracking))
+        self.app.add_handler(CommandHandler("enviar_camaras_mail", iniciar_envio_camaras_mail))
         
         # Callbacks de botones
         self.app.add_handler(CallbackQueryHandler(callback_handler))

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -13,6 +13,10 @@ from .comparador import iniciar_comparador, recibir_tracking, procesar_comparaci
 from .cargar_tracking import iniciar_carga_tracking, guardar_tracking_servicio
 from .descargar_tracking import iniciar_descarga_tracking, enviar_tracking_servicio
 from .descargar_camaras import iniciar_descarga_camaras, enviar_camaras_servicio
+from .enviar_camaras_mail import (
+    iniciar_envio_camaras_mail,
+    procesar_envio_camaras_mail,
+)
 from .id_carrier import iniciar_identificador_carrier, procesar_identificador_carrier
 from .incidencias import iniciar_incidencias, procesar_incidencias
 
@@ -36,6 +40,8 @@ __all__ = [
     'enviar_tracking_servicio',
     'iniciar_descarga_camaras',
     'enviar_camaras_servicio',
+    'iniciar_envio_camaras_mail',
+    'procesar_envio_camaras_mail',
     'iniciar_identificador_carrier',
     'procesar_identificador_carrier',
     'iniciar_incidencias',

--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -63,6 +63,11 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         registrar_conversacion(query.from_user.id, "boton_descargar_camaras", "Inicio descarga camaras", "callback")
         await iniciar_descarga_camaras(update, context)
 
+    elif query.data == "enviar_camaras_mail":
+        from .enviar_camaras_mail import iniciar_envio_camaras_mail
+        registrar_conversacion(query.from_user.id, "boton_enviar_camaras_mail", "Inicio envio camaras", "callback")
+        await iniciar_envio_camaras_mail(update, context)
+
     elif query.data == "id_carrier":
         from .id_carrier import iniciar_identificador_carrier
         registrar_conversacion(query.from_user.id, "boton_id_carrier", "Inicio id carrier", "callback")

--- a/Sandy bot/sandybot/handlers/enviar_camaras_mail.py
+++ b/Sandy bot/sandybot/handlers/enviar_camaras_mail.py
@@ -1,0 +1,114 @@
+"""Manejadores para enviar las cámaras de un servicio por correo electrónico."""
+
+from telegram import Update
+from telegram.ext import ContextTypes
+import logging
+import os
+import tempfile
+import smtplib
+from email.message import EmailMessage
+
+from ..utils import obtener_mensaje
+from ..database import exportar_camaras_servicio
+from ..registrador import responder_registrando, registrar_conversacion
+from .estado import UserState
+
+logger = logging.getLogger(__name__)
+
+
+def _enviar_mail(destino: str, archivo: str) -> None:
+    """Envía un archivo por correo utilizando SMTP simple."""
+    msg = EmailMessage()
+    msg["Subject"] = "Listado de cámaras"
+    msg["From"] = os.getenv("EMAIL_FROM", "bot@example.com")
+    msg["To"] = destino
+    msg.set_content("Adjunto las cámaras solicitadas.")
+    with open(archivo, "rb") as f:
+        datos = f.read()
+    msg.add_attachment(datos, maintype="application", subtype="octet-stream", filename=os.path.basename(archivo))
+    servidor = os.getenv("SMTP_SERVER", "localhost")
+    puerto = int(os.getenv("SMTP_PORT", "25"))
+    with smtplib.SMTP(servidor, puerto) as smtp:
+        smtp.send_message(msg)
+
+
+async def iniciar_envio_camaras_mail(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Solicita ID de servicio y correo para enviar el Excel."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        logger.warning("No se recibió mensaje en iniciar_envio_camaras_mail.")
+        return
+
+    user_id = update.effective_user.id
+    UserState.set_mode(user_id, "enviar_camaras_mail")
+    context.user_data.clear()
+    await responder_registrando(
+        mensaje,
+        user_id,
+        "enviar_camaras_mail",
+        "Escribí el ID del servicio y el mail destino separados por espacio.\nEjemplo: 123 usuario@dominio.com",
+        "enviar_camaras_mail",
+    )
+
+
+async def procesar_envio_camaras_mail(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Genera el Excel de cámaras y lo envía por correo."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje or not mensaje.text:
+        logger.warning("Datos faltantes en procesar_envio_camaras_mail.")
+        return
+
+    partes = mensaje.text.strip().split()
+    if len(partes) != 2 or not partes[0].isdigit():
+        await responder_registrando(
+            mensaje,
+            mensaje.from_user.id,
+            mensaje.text,
+            "Debes indicar ID y correo separados por espacio.",
+            "enviar_camaras_mail",
+        )
+        return
+
+    id_servicio = int(partes[0])
+    correo = partes[1]
+    ruta = os.path.join(tempfile.gettempdir(), f"camaras_{mensaje.from_user.id}.xlsx")
+    ok = exportar_camaras_servicio(id_servicio, ruta)
+    if not ok or not os.path.exists(ruta):
+        await responder_registrando(
+            mensaje,
+            mensaje.from_user.id,
+            mensaje.text,
+            "No hay cámaras registradas para ese servicio.",
+            "enviar_camaras_mail",
+        )
+        return
+
+    try:
+        _enviar_mail(correo, ruta)
+        registrar_conversacion(
+            mensaje.from_user.id,
+            mensaje.text,
+            f"Cámaras enviadas a {correo}",
+            "enviar_camaras_mail",
+        )
+        await responder_registrando(
+            mensaje,
+            mensaje.from_user.id,
+            mensaje.text,
+            f"📧 Cámaras enviadas a {correo}",
+            "enviar_camaras_mail",
+        )
+    except Exception as e:
+        logger.error("Error enviando cámaras por mail: %s", e)
+        await responder_registrando(
+            mensaje,
+            mensaje.from_user.id,
+            mensaje.text,
+            f"Error al enviar el mail: {e}",
+            "enviar_camaras_mail",
+        )
+    finally:
+        UserState.set_mode(update.effective_user.id, "")
+        context.user_data.clear()
+        if os.path.exists(ruta):
+            os.remove(ruta)

--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -75,6 +75,12 @@ async def message_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await enviar_camaras_servicio(update, context)
             return
 
+        # Enviar cámaras por mail
+        if UserState.get_mode(user_id) == "enviar_camaras_mail":
+            from .enviar_camaras_mail import procesar_envio_camaras_mail
+            await procesar_envio_camaras_mail(update, context)
+            return
+
         # Manejo de estado de usuario
         if UserState.is_waiting_detail(user_id):
             await _manejar_detalle_pendiente(update, context, user_id, mensaje_usuario)
@@ -344,6 +350,11 @@ def _detectar_accion_natural(mensaje: str) -> str | None:
             "obtener camaras",
             "bajar camaras",
         ],
+        "enviar_camaras_mail": [
+            "enviar camaras por mail",
+            "enviar cámaras por mail",
+            "camaras por correo",
+        ],
         "id_carrier": [
             "identificador de servicio carrier",
             "id carrier",
@@ -396,6 +407,8 @@ def _detectar_accion_natural(mensaje: str) -> str | None:
         or "obten" in texto
     ):
         return "descargar_camaras"
+    if "camar" in texto and "mail" in texto:
+        return "enviar_camaras_mail"
     if "carrier" in texto and ("ident" in texto or "id" in texto):
         return "id_carrier"
     if "repetit" in texto and "inform" in texto:
@@ -445,6 +458,10 @@ async def _ejecutar_accion_natural(
     elif accion == "descargar_camaras":
         from .descargar_camaras import iniciar_descarga_camaras
         await iniciar_descarga_camaras(update, context)
+        return True
+    elif accion == "enviar_camaras_mail":
+        from .enviar_camaras_mail import iniciar_envio_camaras_mail
+        await iniciar_envio_camaras_mail(update, context)
         return True
     elif accion == "id_carrier":
         await iniciar_identificador_carrier(update, context)

--- a/Sandy bot/sandybot/handlers/start.py
+++ b/Sandy bot/sandybot/handlers/start.py
@@ -19,6 +19,7 @@ async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         ],
         [
            InlineKeyboardButton("⬇️ Descargar cámaras", callback_data="descargar_camaras"),
+           InlineKeyboardButton("📧 Enviar cámaras por mail", callback_data="enviar_camaras_mail"),
         ],
         [
            InlineKeyboardButton(


### PR DESCRIPTION
## Resumen
- agregar botón '📧 Enviar cámaras por mail'
- implementar manejadores para exportar cámaras a Excel y enviarlas por correo
- registrar los nuevos handlers en el paquete
- soportar la acción por comandos y callbacks
- actualizar la detección de acciones en lenguaje natural

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475ff6a9d483308d8421a3b5ef22f4