### PR TITLE
Añadir envío de Excel por correo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ El comportamiento de SandyBot se ajusta mediante varias variables de entorno:
 - `PLANTILLA_PATH`: ruta de la plantilla para los informes de repetitividad. Si
   no se define, se usa `C:\Metrotel\Sandy\plantilla_informe.docx`.
 - `GPT_MODEL`: modelo de OpenAI a emplear. Por defecto se aplica `gpt-4`.
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`: datos para el servidor
+  de correo saliente.
+- `SMTP_USE_TLS`: indica si se inicia TLS al conectarse (por defecto `true`).
 
 ## Plantilla de informes de repetitividad
 
@@ -83,11 +86,34 @@ Si necesitás procesar documentos con extensión `.doc`, instalá el paquete opc
 pip install textract
 ```
 
+
 También podés incluirlo al instalar todas las dependencias:
 
 ```bash
 pip install -r requirements.txt
 ```
+
+## Enviar Excel por correo
+
+Para mandar un reporte por email se usa la función `enviar_excel_por_correo()`
+de `sandybot.email_utils`. No requiere instalar paquetes adicionales porque
+aprovecha `smtplib` y `email` de la biblioteca estándar.
+
+```python
+from sandybot.email_utils import enviar_excel_por_correo
+
+exito = enviar_excel_por_correo(
+    "destino@example.com",
+    "reporte.xlsx",
+    asunto="Reporte semanal",
+    cuerpo="Adjunto el archivo solicitado."
+)
+if exito:
+    print("Correo enviado correctamente")
+```
+
+Asegurate de definir `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER` y `SMTP_PASSWORD`
+en tu `.env` para que el envío funcione.
 
 
 ## Errores por variables de entorno faltantes

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -73,6 +73,13 @@ class Config:
         self.DB_NAME = os.getenv("DB_NAME", "sandybot")
         self.DB_USER = os.getenv("DB_USER")
         self.DB_PASSWORD = os.getenv("DB_PASSWORD")
+
+        # SMTP
+        self.SMTP_HOST = os.getenv("SMTP_HOST")
+        self.SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
+        self.SMTP_USER = os.getenv("SMTP_USER")
+        self.SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
+        self.SMTP_USE_TLS = os.getenv("SMTP_USE_TLS", "true").lower() == "true"
         
         # Validación
         self.validate()

--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -1,0 +1,65 @@
+"""Funciones para enviar archivos por correo."""
+
+from pathlib import Path
+import logging
+import smtplib
+from email.message import EmailMessage
+
+from .config import config
+
+logger = logging.getLogger(__name__)
+
+
+def enviar_excel_por_correo(destinatario: str, ruta_excel: str, *, asunto: str = "Reporte SandyBot", cuerpo: str = "Adjunto el archivo Excel.") -> bool:
+    """Envía un archivo Excel por correo usando la configuración SMTP.
+
+    Parameters
+    ----------
+    destinatario: str
+        Dirección de correo del destinatario.
+    ruta_excel: str
+        Ruta al archivo Excel a adjuntar.
+    asunto: str, optional
+        Asunto del mensaje.
+    cuerpo: str, optional
+        Texto del cuerpo del correo.
+
+    Returns
+    -------
+    bool
+        ``True`` si el envío fue exitoso, ``False`` en caso de error.
+    """
+    try:
+        ruta = Path(ruta_excel)
+        if not ruta.exists():
+            raise FileNotFoundError(f"No se encontró el archivo: {ruta}")
+
+        msg = EmailMessage()
+        msg["From"] = config.SMTP_USER
+        msg["To"] = destinatario
+        msg["Subject"] = asunto
+        msg.set_content(cuerpo)
+
+        with open(ruta, "rb") as f:
+            datos = f.read()
+        msg.add_attachment(
+            datos,
+            maintype="application",
+            subtype="vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            filename=ruta.name,
+        )
+
+        if config.SMTP_USE_TLS:
+            server = smtplib.SMTP(config.SMTP_HOST, config.SMTP_PORT)
+            server.starttls()
+        else:
+            server = smtplib.SMTP_SSL(config.SMTP_HOST, config.SMTP_PORT)
+
+        server.login(config.SMTP_USER, config.SMTP_PASSWORD)
+        server.send_message(msg)
+        server.quit()
+        return True
+
+    except Exception as e:  # pragma: no cover - errores dependen del entorno
+        logger.error("Error enviando correo: %s", e)
+        return False

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -1,0 +1,63 @@
+import sys
+import types
+import os
+import importlib
+from pathlib import Path
+
+# Preparar rutas
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT_DIR / "Sandy bot"))
+
+# Stub de dotenv para Config
+dotenv_stub = types.ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+# Stub de smtplib para verificar el envío
+smtp_stub = types.ModuleType("smtplib")
+reg = {"sent": False, "tls": False, "login": None}
+class SMTP:
+    def __init__(self, host, port):
+        reg["host"] = host
+        reg["port"] = port
+    def starttls(self):
+        reg["tls"] = True
+    def login(self, user, pwd):
+        reg["login"] = (user, pwd)
+    def send_message(self, msg):
+        reg["sent"] = True
+        reg["to"] = msg["To"]
+        reg["subject"] = msg["Subject"]
+    def quit(self):
+        pass
+smtp_stub.SMTP = SMTP
+smtp_stub.SMTP_SSL = SMTP
+sys.modules.setdefault("smtplib", smtp_stub)
+
+# Variables de entorno mínimas
+os.environ.update({
+    "TELEGRAM_TOKEN": "x",
+    "OPENAI_API_KEY": "x",
+    "NOTION_TOKEN": "x",
+    "NOTION_DATABASE_ID": "x",
+    "DB_USER": "u",
+    "DB_PASSWORD": "p",
+    "SMTP_HOST": "smtp.example.com",
+    "SMTP_PORT": "25",
+    "SMTP_USER": "bot@example.com",
+    "SMTP_PASSWORD": "pwd",
+})
+
+config_mod = importlib.import_module("sandybot.config")
+email_utils = importlib.import_module("sandybot.email_utils")
+
+
+def test_enviar_excel_por_correo(tmp_path):
+    ruta = tmp_path / "archivo.xlsx"
+    ruta.write_text("datos")
+
+    ok = email_utils.enviar_excel_por_correo("dest@example.com", str(ruta))
+    assert ok is True
+    assert reg["sent"] is True
+    assert reg["tls"] is True
+    assert reg["login"] == ("bot@example.com", "pwd")


### PR DESCRIPTION
## Summary
- documentar nuevas variables SMTP en README
- explicar cómo enviar un Excel por correo
- añadir configuración SMTP en el código
- crear utilidad `enviar_excel_por_correo`
- testear la nueva función

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476002b13c8330bf5221a446bced11