### PR TITLE
Unifica configuraciones de correo y documenta licencia

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,3 +157,8 @@ Salida esperada:
 ]
 
 ☑️ Este documento debe mantenerse actualizado a medida que Sandy evoluciona. Puedes encontrarlo en AGENTS.md en la raíz del repositorio.
+
+## 📧 Envío de correos
+
+El bot puede enviar listados por email usando los destinatarios guardados en `Sandy bot/data/destinatarios.json`. Configurá `SMTP_HOST`, `SMTP_PORT` y `EMAIL_FROM` en el `.env`.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 NiceGrow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ El comportamiento de SandyBot se ajusta mediante varias variables de entorno:
   no se define, se usa `C:\Metrotel\Sandy\plantilla_informe.docx`.
 - `GPT_MODEL`: modelo de OpenAI a emplear. Por defecto se aplica `gpt-4`.
 
+### Envío de correos
+
+Para adjuntar archivos por email se utilizan las siguientes variables opcionales:
+
+- `SMTP_HOST` y `SMTP_PORT`: servidor y puerto del servicio SMTP.
+- `SMTP_USER` y `SMTP_PASSWORD`: credenciales si el servidor las requiere.
+- `EMAIL_FROM`: dirección remitente utilizada en los mensajes.
+
 ## Plantilla de informes de repetitividad
 
 El documento base para generar los reportes de repetitividad se indica
@@ -104,4 +112,9 @@ Verificá tu archivo .env o las variables del sistema.
 Este texto se registra con `logging.error` y luego se lanza una excepción
 `ValueError` con el mismo contenido. Revisá el archivo `.env` o la configuración
 del sistema para corregir el problema.
+
+
+## Licencia
+
+Este proyecto se publica bajo la licencia [MIT](LICENSE).
 

--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -147,6 +147,7 @@ admitir listas sin procesamiento adicional.
 5. Descarga de cámaras
    - Seleccioná "Descargar cámaras" desde el menú o enviá `/descargar_camaras`
    - Indicá el ID y recibirás un Excel con todas las cámaras asociadas
+   - También podés usar `/enviar_camaras_mail` para recibirlas por correo
 
 6. Informes de repetitividad
    - Procesa Excel de casos
@@ -171,4 +172,4 @@ admitir listas sin procesamiento adicional.
 
 ## Licencia
 
-Este proyecto está licenciado bajo [insertar licencia].
+El código se distribuye bajo la licencia [MIT](../LICENSE).

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -63,7 +63,7 @@ class Config:
         # Registro histórico de interacciones por usuario
         self.ARCHIVO_INTERACCIONES = self.DATA_DIR / "interacciones.json"
         # Lista de destinatarios de notificaciones
-        self.ARCHIVO_DESTINATARIOS = self.DATA_DIR / "destinatarios.json"
+        self.DESTINATARIOS_FILE = self.DATA_DIR / "destinatarios.json"
         self.LOG_FILE = self.LOG_DIR / "sandy.log"
         self.ERRORES_FILE = self.LOG_DIR / "errores_ingresos.log"
         # Cache de consultas a GPT para reducir costos y latencia
@@ -100,18 +100,10 @@ class Config:
         self.SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
         self.SMTP_USER = os.getenv("SMTP_USER")
         self.SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
-        self.EMAIL_FROM = os.getenv("EMAIL_FROM")
-
-        # Ruta del archivo que almacena los destinatarios para los envíos
-        # automáticos de reportes o listados.
-        self.DESTINATARIOS_FILE = self.DATA_DIR / "destinatarios.json"
-
-        # Credenciales de correo electrónico
-        self.EMAIL_HOST = os.getenv("EMAIL_HOST", "smtp.gmail.com")
-        self.EMAIL_PORT = int(os.getenv("EMAIL_PORT", "465"))
         self.EMAIL_USER = os.getenv("EMAIL_USER")
         self.EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
         self.EMAIL_FROM = os.getenv("EMAIL_FROM")
+
 
         
         # Validación

--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -35,13 +35,7 @@ engine = create_engine(
     DATABASE_URL, pool_size=5, max_overflow=10, pool_timeout=30, pool_recycle=1800
 )
 
-# Selecciona el tipo JSON adecuado según la base de datos.
-if engine.url.get_backend_name() == "sqlite":
-    JSONType = JSON
-else:
-    JSONType = JSONB
-
-# Determina el tipo JSON a utilizar según la base de datos
+# Selecciona el tipo JSON adecuado según la base de datos
 if engine.dialect.name == "postgresql":
     from sqlalchemy.dialects.postgresql import JSONB as JSONType
 else:  # pragma: no cover - para SQLite en tests

--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -1,4 +1,3 @@
-
 """Utilidades sencillas para el envio de correos."""
 
 import smtplib

--- a/Sandy bot/sandybot/handlers/enviar_camaras_mail.py
+++ b/Sandy bot/sandybot/handlers/enviar_camaras_mail.py
@@ -8,6 +8,8 @@ import tempfile
 import smtplib
 from email.message import EmailMessage
 
+from ..config import config
+
 from ..utils import obtener_mensaje
 from ..database import exportar_camaras_servicio
 from ..registrador import responder_registrando, registrar_conversacion
@@ -20,14 +22,14 @@ def _enviar_mail(destino: str, archivo: str) -> None:
     """Envía un archivo por correo utilizando SMTP simple."""
     msg = EmailMessage()
     msg["Subject"] = "Listado de cámaras"
-    msg["From"] = os.getenv("EMAIL_FROM", "bot@example.com")
+    msg["From"] = config.EMAIL_FROM or "bot@example.com"
     msg["To"] = destino
     msg.set_content("Adjunto las cámaras solicitadas.")
     with open(archivo, "rb") as f:
         datos = f.read()
     msg.add_attachment(datos, maintype="application", subtype="octet-stream", filename=os.path.basename(archivo))
-    servidor = os.getenv("SMTP_SERVER", "localhost")
-    puerto = int(os.getenv("SMTP_PORT", "25"))
+    servidor = config.SMTP_HOST or "localhost"
+    puerto = config.SMTP_PORT
     with smtplib.SMTP(servidor, puerto) as smtp:
         smtp.send_message(msg)
 

--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -552,4 +552,4 @@ def _generar_prompt_por_animo(mensaje: str, puntaje: int) -> str:
         )
     if puntaje <= 80:
         return _generar_prompt_malhumorado(mensaje) + " Explicá con mucho detalle."
-    return _generar_prompt_malhumorado(mensaje) + " Sé muy directo y fastidioso." 
+    return _generar_prompt_malhumorado(mensaje) + " Sé muy directo y fastidioso."

--- a/Sandy bot/sandybot/tracking_parser.py
+++ b/Sandy bot/sandybot/tracking_parser.py
@@ -71,4 +71,3 @@ class TrackingParser:
                 df.to_excel(writer, sheet_name=sheet, index=False)
             coincidencias.to_excel(writer, sheet_name="Coincidencias", index=False)
 
-            

--- a/Sandy bot/sandybot/utils.py
+++ b/Sandy bot/sandybot/utils.py
@@ -95,11 +95,11 @@ def cargar_destinatarios() -> Dict[str, Any]:
     """Carga el archivo de destinatarios definido en :class:`Config`."""
     from .config import config
 
-    return cargar_json(config.ARCHIVO_DESTINATARIOS)
+    return cargar_json(config.DESTINATARIOS_FILE)
 
 
 def guardar_destinatarios(destinatarios: Dict[str, Any]) -> bool:
     """Guarda la lista de destinatarios en el archivo configurado."""
     from .config import config
 
-    return guardar_json(destinatarios, config.ARCHIVO_DESTINATARIOS)
+    return guardar_json(destinatarios, config.DESTINATARIOS_FILE)


### PR DESCRIPTION
## Resumen
- normaliza selección de JSON en database.py
- consolida variables de correo en config.py y utilidades
- ajusta envío de mails con `SMTP_HOST` y `SMTP_PORT`
- corrige espacios finales y líneas vacías
- documenta variables SMTP y nueva función en README
- añade aviso de correo en AGENTS.md
- incorpora archivo LICENSE

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847568ecc708330bfc796ed26567c8e