### PR TITLE
Actualizar transcripción de audio a API async

### DIFF
--- a/Sandy bot/sandybot/handlers/voice.py
+++ b/Sandy bot/sandybot/handlers/voice.py
@@ -3,6 +3,7 @@ import logging
 import tempfile
 import os
 import openai
+from ..config import config
 from telegram import Update
 from telegram.ext import ContextTypes
 from ..registrador import responder_registrando
@@ -22,7 +23,8 @@ async def voice_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     try:
         await voice.download_to_drive(path)
         with open(path, "rb") as audio:
-            transcripcion = await openai.Audio.transcriptions.create(
+            client = openai.AsyncOpenAI(api_key=config.OPENAI_API_KEY)
+            transcripcion = await client.audio.transcriptions.create(
                 file=audio,
                 model="whisper-1",
             )


### PR DESCRIPTION
## Summary
- usar `openai.AsyncOpenAI` en el manejador de voz

## Testing
- `pytest -q`
- `python - <<'PY'
import asyncio, openai
async def test():
    client = openai.AsyncOpenAI(api_key='invalid')
    try:
        with open('sample.wav','rb') as f:
            await client.audio.transcriptions.create(file=f, model='whisper-1')
    except Exception as e:
        print('error:', e)
asyncio.run(test())
PY`


------
https://chatgpt.com/codex/tasks/task_e_684767494b8483308e7d7a89d68d1da5