### PR TITLE
Correcciones para envío de correos

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ Para adjuntar archivos por email se utilizan las siguientes variables opcionales
 - `SMTP_USER` y `SMTP_PASSWORD`: credenciales si el servidor las requiere.
 - `EMAIL_FROM`: dirección remitente utilizada en los mensajes.
 
+Si vas a usar Gmail en desarrollo, activá la verificación en dos pasos y generá
+una **contraseña de aplicación**. Definí las variables así:
+
+```env
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=tu_correo@gmail.com
+SMTP_PASSWORD=tu_contraseña_de_app
+EMAIL_FROM=tu_correo@gmail.com
+```
+
 ## Plantilla de informes de repetitividad
 
 El documento base para generar los reportes de repetitividad se indica

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -100,8 +100,6 @@ class Config:
         self.SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
         self.SMTP_USER = os.getenv("SMTP_USER")
         self.SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
-        self.EMAIL_USER = os.getenv("EMAIL_USER")
-        self.EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
         self.EMAIL_FROM = os.getenv("EMAIL_FROM")
 
 
@@ -140,7 +138,7 @@ class Config:
         # Advertir si faltan datos de correo
         email_missing = [
             nombre
-            for nombre in ["EMAIL_USER", "EMAIL_PASSWORD", "EMAIL_FROM"]
+            for nombre in ["SMTP_HOST", "SMTP_USER", "SMTP_PASSWORD", "EMAIL_FROM"]
             if not getattr(self, nombre)
         ]
         if email_missing:

--- a/Sandy bot/sandybot/handlers/enviar_camaras_mail.py
+++ b/Sandy bot/sandybot/handlers/enviar_camaras_mail.py
@@ -27,10 +27,19 @@ def _enviar_mail(destino: str, archivo: str) -> None:
     msg.set_content("Adjunto las cámaras solicitadas.")
     with open(archivo, "rb") as f:
         datos = f.read()
-    msg.add_attachment(datos, maintype="application", subtype="octet-stream", filename=os.path.basename(archivo))
+    msg.add_attachment(
+        datos,
+        maintype="application",
+        subtype="octet-stream",
+        filename=os.path.basename(archivo),
+    )
+
     servidor = config.SMTP_HOST or "localhost"
     puerto = config.SMTP_PORT
     with smtplib.SMTP(servidor, puerto) as smtp:
+        smtp.starttls()
+        if config.SMTP_USER and config.SMTP_PASSWORD:
+            smtp.login(config.SMTP_USER, config.SMTP_PASSWORD)
         smtp.send_message(msg)
 
 


### PR DESCRIPTION
## Summary
- ajustar documentación sobre variables SMTP y ejemplo para Gmail
- limpiar `Config` eliminando variables de correo sin uso y avisando si faltan credenciales
- autenticar el envío en `enviar_camaras_mail`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476592ebc08330a12e2e55629d4a9c