### PR TITLE
Añadidas funciones de correo

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -4,9 +4,11 @@
 from pathlib import Path
 import logging
 import smtplib
+import os
 from email.message import EmailMessage
 
 from .config import config
+from .utils import cargar_json, guardar_json
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +38,14 @@ def enviar_excel_por_correo(destinatario: str, ruta_excel: str, *, asunto: str =
             raise FileNotFoundError(f"No se encontró el archivo: {ruta}")
 
         msg = EmailMessage()
-        msg["From"] = config.SMTP_USER
+        smtp_user = getattr(config, "SMTP_USER", os.getenv("SMTP_USER"))
+        smtp_pass = getattr(config, "SMTP_PASSWORD", os.getenv("SMTP_PASSWORD"))
+        from_addr = getattr(config, "EMAIL_FROM", smtp_user)
+        host = getattr(config, "SMTP_HOST", os.getenv("SMTP_HOST", "localhost"))
+        port = int(getattr(config, "SMTP_PORT", os.getenv("SMTP_PORT", 25)))
+        use_tls = getattr(config, "SMTP_USE_TLS", True)
+
+        msg["From"] = from_addr
         msg["To"] = destinatario
         msg["Subject"] = asunto
         msg.set_content(cuerpo)
@@ -50,17 +59,86 @@ def enviar_excel_por_correo(destinatario: str, ruta_excel: str, *, asunto: str =
             filename=ruta.name,
         )
 
-        if config.SMTP_USE_TLS:
-            server = smtplib.SMTP(config.SMTP_HOST, config.SMTP_PORT)
+        if use_tls:
+            server = smtplib.SMTP(host, port)
             server.starttls()
         else:
-            server = smtplib.SMTP_SSL(config.SMTP_HOST, config.SMTP_PORT)
+            server = smtplib.SMTP_SSL(host, port)
 
-        server.login(config.SMTP_USER, config.SMTP_PASSWORD)
+        if smtp_user and smtp_pass:
+            server.login(smtp_user, smtp_pass)
         server.send_message(msg)
         server.quit()
         return True
 
     except Exception as e:  # pragma: no cover - errores dependen del entorno
+        logger.error("Error enviando correo: %s", e)
+        return False
+
+
+def cargar_destinatarios(ruta: Path) -> list[str]:
+    """Devuelve la lista de correos almacenados en ``ruta``.
+
+    El archivo JSON debe contener una clave ``"emails"`` con una lista de
+    direcciones.  Si el archivo no existe se devuelve una lista vacía.
+    """
+    datos = cargar_json(ruta)
+    return datos.get("emails", [])
+
+
+def agregar_destinatario(correo: str, ruta: Path) -> bool:
+    """Agrega ``correo`` a la lista de destinatarios almacenada en ``ruta``."""
+    correos = cargar_destinatarios(ruta)
+    if correo in correos:
+        return True
+    correos.append(correo)
+    return guardar_json({"emails": correos}, ruta)
+
+
+def eliminar_destinatario(correo: str, ruta: Path) -> bool:
+    """Elimina ``correo`` de la lista guardada en ``ruta``."""
+    correos = cargar_destinatarios(ruta)
+    if correo not in correos:
+        return True
+    correos.remove(correo)
+    return guardar_json({"emails": correos}, ruta)
+
+
+def enviar_correo(asunto: str, cuerpo: str, ruta_json: Path, *, host=None, port=None) -> bool:
+    """Envía un correo de texto a todos los destinatarios registrados.
+
+    Parameters
+    ----------
+    asunto: str
+        Título del mensaje.
+    cuerpo: str
+        Contenido principal del mensaje.
+    ruta_json: Path
+        Ruta al archivo con los destinatarios.
+    host: str, optional
+        Servidor SMTP a utilizar.  Si no se indica se toma de la configuración
+        o ``localhost`` como último recurso.
+    port: int, optional
+        Puerto del servidor SMTP.  Si se omite se toma de la configuración o
+        ``25`` por defecto.
+    """
+
+    destinos = cargar_destinatarios(ruta_json)
+    if not destinos:
+        logger.warning("No se encontraron destinatarios en %s", ruta_json)
+        return False
+
+    remitente = getattr(config, "EMAIL_FROM", "bot@example.com")
+    host = host or getattr(config, "SMTP_HOST", "localhost")
+    port = int(port or getattr(config, "SMTP_PORT", 25))
+
+    mensaje = f"Subject: {asunto}\nFrom: {remitente}\n\n{cuerpo}"
+
+    try:
+        with smtplib.SMTP(host, port) as smtp:
+            smtp.set_debuglevel(1)
+            smtp.sendmail(remitente, destinos, mensaje)
+        return True
+    except Exception as e:  # pragma: no cover - entorno depende del sistema
         logger.error("Error enviando correo: %s", e)
         return False

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -37,6 +37,9 @@ for var in [
     "NOTION_DATABASE_ID",
     "DB_USER",
     "DB_PASSWORD",
+    "SLACK_WEBHOOK_URL",
+    "SUPERVISOR_DB_ID",
+    "EMAIL_FROM",
 ]:
     os.environ.setdefault(var, "x")
 

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -32,7 +32,7 @@ class SMTP:
         pass
 smtp_stub.SMTP = SMTP
 smtp_stub.SMTP_SSL = SMTP
-sys.modules.setdefault("smtplib", smtp_stub)
+sys.modules["smtplib"] = smtp_stub
 
 # Variables de entorno mínimas
 os.environ.update({
@@ -49,7 +49,7 @@ os.environ.update({
 })
 
 config_mod = importlib.import_module("sandybot.config")
-email_utils = importlib.import_module("sandybot.email_utils")
+email_utils = importlib.reload(importlib.import_module("sandybot.email_utils"))
 
 
 def test_enviar_excel_por_correo(tmp_path):


### PR DESCRIPTION
## Summary
- manejar destinatarios de correo en `email_utils`
- enviar texto por SMTP a varios destinatarios
- recargar `email_utils` correctamente en las pruebas
- definir variables requeridas para las pruebas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68477860a7f08330a0a29d9ff17df6ea