### PR TITLE
Update SMTP_PORT env var in test

### DIFF
--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -58,7 +58,7 @@ for var in [
     "SMTP_PASSWORD",
     "EMAIL_FROM",
 ]:
-    os.environ.setdefault(var, "x")
+    os.environ.setdefault(var, "25" if var == "SMTP_PORT" else "x")
 
 # Stub openai compatible con GPTHandler y voice_handler
 openai_stub = ModuleType("openai")


### PR DESCRIPTION
## Summary
- ajusto el valor de `SMTP_PORT` en el test `test_voice_handler` para usar el puerto 25

## Testing
- `pytest tests/test_voice_handler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848079b55c483308d1d419f17a90fd0