### PR TITLE
Actualizar README sobre extensiones de Postgres

### DIFF
--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -25,6 +25,16 @@ Bot de Telegram para gestión de infraestructura de fibra óptica.
 - Microsoft Word (para informes de repetitividad)
 - Paquete `openai` versión 1.0.0 o superior
 
+Para que el bot funcione correctamente la base de datos debe contar con las
+extensiones `unaccent` y `pg_trgm`. El usuario usado por SandyBot tiene que
+tener permisos suficientes para crearlas o bien un administrador debe
+habilitarlas de antemano. Los comandos son:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS unaccent;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+```
+
 ## Instalación
 
 1. Clonar el repositorio:


### PR DESCRIPTION
## Resumen
- aclarar que la base requiere `unaccent` y `pg_trgm`
- añadir comandos de ejemplo para crear las extensiones

## Testing
- `pytest -q` *(falla 1 prueba)*

------
https://chatgpt.com/codex/tasks/task_e_68480f835f8c8330b7f59fa5e2484ac7