### PR TITLE
Actualización del README sobre SMTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ una **contraseña de aplicación**. Definí las variables así:
 SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
 SMTP_USER=tu_correo@gmail.com
-SMTP_PASSWORD=tu_contraseña_de_app
+SMTP_PASSWORD=tu_contrasena_de_app  # sin espacios
 EMAIL_FROM=tu_correo@gmail.com
 ```
+Nota: si copiás la contraseña de aplicación de Gmail, asegurate de quitar los espacios que se muestran por legibilidad.
 
 ## Plantilla de informes de repetitividad
 


### PR DESCRIPTION
## Resumen
- aclaro el uso de la contraseña de app de Gmail en las variables SMTP y se agrega una nota sobre los espacios

## Testing
- `pytest -q` *(falla: ModuleNotFoundError: no module named openpyxl/docx)*

------
https://chatgpt.com/codex/tasks/task_e_68481c0191488330b16ccde86ae82c83