### PR TITLE
Mejora de setup_env y dependencias de tests

### DIFF
--- a/Sandy bot/requirements.txt
+++ b/Sandy bot/requirements.txt
@@ -11,5 +11,5 @@ python-Levenshtein>=0.12.0
 pywin32>=300; sys_platform == 'win32'
 jsonschema>=4.0.0
 SQLAlchemy>=1.4
-textract>=1.0.0  # opcional para archivos .doc
+textract==1.6.3  # opcional para archivos .doc
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,4 +1,17 @@
-#!/bin/bash
-python3 -m venv .venv
+#!/usr/bin/env bash
+set -e
+
+# Directorio para la cache de pip
+PIP_CACHE_DIR="$HOME/.cache/pip"
+mkdir -p "$PIP_CACHE_DIR"
+
+# Crear y activar el entorno virtual
+python -m venv .venv
 source .venv/bin/activate
-pip install -r "Sandy bot/requirements.txt"
+
+# Actualizar pip e instalar dependencias
+pip install --upgrade pip
+pip install --cache-dir "$PIP_CACHE_DIR" -r "Sandy bot/requirements.txt"
+
+# Herramientas de pruebas
+pip install pytest pytest-cov


### PR DESCRIPTION
## Resumen
- se actualiza `setup_env.sh` para gestionar caché de pip y añadir pytest
- se fija versión de `textract` en requirements para evitar errores de instalación

## Testing
- `bash setup_env.sh`
- `pytest -q` dentro del entorno virtual

------
https://chatgpt.com/codex/tasks/task_e_68482cdec7e88330b2b34065b4b3de60