### PR TITLE
Manejo cadenas en camaras

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -223,6 +223,13 @@ def actualizar_tracking(
         if ruta is not None:
             servicio.ruta_tracking = ruta
         if camaras is not None:
+            # Si las cámaras llegan como cadena (caso de registros antiguos),
+            # se intenta convertir desde JSON para guardar siempre una lista.
+            if isinstance(camaras, str):
+                try:
+                    camaras = json.loads(camaras)
+                except json.JSONDecodeError:
+                    camaras = []
             servicio.camaras = camaras
         if trackings_txt:
             existentes = servicio.trackings or []
@@ -302,7 +309,13 @@ def exportar_camaras_servicio(id_servicio: int, ruta_excel: str) -> bool:
         return False
 
     camaras = servicio.camaras
-
+    # Compatibilidad con campos almacenados como texto JSON. Si es una cadena,
+    # se intenta decodificar para obtener la lista de cámaras.
+    if isinstance(camaras, str):
+        try:
+            camaras = json.loads(camaras)
+        except json.JSONDecodeError:
+            return False
 
     # Se crea el DataFrame con una única columna
     df = pd.DataFrame(camaras, columns=["camara"])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -115,6 +115,23 @@ def test_exportar_camaras_servicio(tmp_path):
     assert filas == ["camara", "Camara 1", "Camara 2"]
 
 
+def test_exportar_camaras_servicio_cadena(tmp_path):
+    """Verifica la exportación cuando las cámaras se guardaron como texto JSON."""
+    servicio = bd.crear_servicio(
+        nombre="S4b", cliente="D", camaras='["C1", "C2"]'
+    )
+
+    ruta = tmp_path / "camaras_str.xlsx"
+    ok = bd.exportar_camaras_servicio(servicio.id, str(ruta))
+    assert ok is True
+    assert ruta.exists()
+
+    wb = openpyxl.load_workbook(ruta)
+    ws = wb.active
+    filas = [c[0].value for c in ws.iter_rows(values_only=False)]
+    assert filas == ["camara", "C1", "C2"]
+
+
 def test_actualizar_tracking_jsonb():
     servicio = bd.crear_servicio(nombre="S6", cliente="F")
     bd.actualizar_tracking(servicio.id, "ruta.txt", ["C1"], ["t1.txt"])


### PR DESCRIPTION
## Summary
- normalizar `camaras` en `actualizar_tracking` para aceptar texto JSON
- permitir que `exportar_camaras_servicio` procese cadenas JSON
- agregar prueba que usa `camaras` como cadena JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483fdba0f48330b042d8607d29baf3