### PR TITLE
Clarify unaccent function usage

### DIFF
--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -35,6 +35,10 @@ CREATE EXTENSION IF NOT EXISTS unaccent;
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 ```
 
+La función `immutable_unaccent` que crea `database.py` invoca
+`public.unaccent`. Si instalás la extensión en otro esquema,
+ajustá la instrucción para utilizar el nombre completo correspondiente.
+
 ## Instalación
 
 1. Clonar el repositorio:

--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -166,7 +166,10 @@ def init_db():
                 conn.execute(
                     text(
                         "CREATE OR REPLACE FUNCTION immutable_unaccent(text)\n"
-                        "RETURNS text AS $$ SELECT unaccent($1) $$\n"
+                        # Se invoca "public.unaccent" porque el esquema
+                        # "public" puede no estar en el ``search_path`` al
+                        # crear la función.
+                        "RETURNS text AS $$ SELECT public.unaccent($1) $$\n"
                         "LANGUAGE SQL IMMUTABLE"
                     )
                 )


### PR DESCRIPTION
## Summary
- call `public.unaccent` when creating immutable function
- document how to adjust the schema in case of custom installation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_68481726b6e4833085a8aa7d52b04813