### PR TITLE
Adjuntos con contador diario

### DIFF
--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -158,10 +158,14 @@ admitir listas sin procesamiento adicional.
 4. Descarga de tracking
    - Elegí "Descargar tracking" desde el menú o escribí `/descargar_tracking`
    - Indicá el número de servicio y recibirás el `.txt` si está disponible
+   - Con `enviar_tracking_reciente_por_correo()` podés recibir por mail el
+     último archivo del histórico con nombre `Tracking_ID_DDMMAAAA_NN.txt`.
 5. Descarga de cámaras
    - Seleccioná "Descargar cámaras" desde el menú o enviá `/descargar_camaras`
    - Indicá el ID y recibirás un Excel con todas las cámaras asociadas
-   - También podés usar `/enviar_camaras_mail` para recibirlas por correo
+   - También podés usar `/enviar_camaras_mail` para recibirlas por correo.
+   - Los archivos se nombran `Camaras_ID_DDMMAAAA_NN.xlsx` según un contador
+     diario.
 
 6. Informes de repetitividad
    - Procesa Excel de casos

--- a/Sandy bot/sandybot/correo.py
+++ b/Sandy bot/sandybot/correo.py
@@ -7,7 +7,7 @@ from .config import config
 logger = logging.getLogger(__name__)
 
 
-def enviar_email(destinatarios, asunto, cuerpo, archivo_adjunto):
+def enviar_email(destinatarios, asunto, cuerpo, archivo_adjunto, nombre_adjunto=None):
     """Envía un correo con un adjunto.
 
     Parameters
@@ -39,8 +39,10 @@ def enviar_email(destinatarios, asunto, cuerpo, archivo_adjunto):
     try:
         with open(archivo_adjunto, "rb") as f:
             datos = f.read()
-            nombre = os.path.basename(archivo_adjunto)
-        msg.add_attachment(datos, maintype="application", subtype="octet-stream", filename=nombre)
+            nombre = nombre_adjunto or os.path.basename(archivo_adjunto)
+        msg.add_attachment(
+            datos, maintype="application", subtype="octet-stream", filename=nombre
+        )
     except Exception as e:
         logger.error("No se pudo adjuntar el archivo: %s", e)
         return False

--- a/Sandy bot/sandybot/handlers/enviar_camaras_mail.py
+++ b/Sandy bot/sandybot/handlers/enviar_camaras_mail.py
@@ -19,7 +19,7 @@ from .estado import UserState
 logger = logging.getLogger(__name__)
 
 
-def _enviar_mail(destino: str, archivo: str) -> None:
+def _enviar_mail(destino: str, archivo: str, nombre: str) -> None:
     """Envía un archivo por correo utilizando SMTP simple."""
     msg = EmailMessage()
     msg["Subject"] = "Listado de cámaras"
@@ -32,7 +32,7 @@ def _enviar_mail(destino: str, archivo: str) -> None:
         datos,
         maintype="application",
         subtype="octet-stream",
-        filename=os.path.basename(archivo),
+        filename=nombre,
     )
 
     servidor = config.SMTP_HOST or "localhost"
@@ -54,7 +54,9 @@ def _enviar_mail(destino: str, archivo: str) -> None:
             smtp.send_message(msg)
 
 
-async def iniciar_envio_camaras_mail(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def iniciar_envio_camaras_mail(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     """Solicita ID de servicio y correo para enviar el Excel."""
     mensaje = obtener_mensaje(update)
     if not mensaje:
@@ -73,7 +75,9 @@ async def iniciar_envio_camaras_mail(update: Update, context: ContextTypes.DEFAU
     )
 
 
-async def procesar_envio_camaras_mail(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def procesar_envio_camaras_mail(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     """Genera el Excel de cámaras y lo envía por correo."""
     mensaje = obtener_mensaje(update)
     if not mensaje or not mensaje.text:
@@ -116,8 +120,11 @@ async def procesar_envio_camaras_mail(update: Update, context: ContextTypes.DEFA
         )
         return
 
+    from ..email_utils import generar_nombre_camaras
+
     try:
-        _enviar_mail(correo, ruta)
+        nombre_archivo = generar_nombre_camaras(id_servicio) + ".xlsx"
+        _enviar_mail(correo, ruta, nombre_archivo)
         registrar_conversacion(
             mensaje.from_user.id,
             mensaje.text,

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -3,6 +3,7 @@ import types
 import os
 import importlib
 from pathlib import Path
+from datetime import datetime
 
 # Preparar rutas
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -16,40 +17,56 @@ sys.modules.setdefault("dotenv", dotenv_stub)
 # Stub de smtplib para verificar el envío
 smtp_stub = types.ModuleType("smtplib")
 reg = {"sent": False, "tls": False, "login": None}
+
+
 class SMTP:
     def __init__(self, host, port):
         reg["host"] = host
         reg["port"] = port
+
     def starttls(self):
         reg["tls"] = True
+
     def login(self, user, pwd):
         reg["login"] = (user, pwd)
+
     def send_message(self, msg):
         reg["sent"] = True
         reg["to"] = msg["To"]
         reg["subject"] = msg["Subject"]
+
     def quit(self):
         pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
 smtp_stub.SMTP = SMTP
 smtp_stub.SMTP_SSL = SMTP
 sys.modules["smtplib"] = smtp_stub
 
 # Variables de entorno mínimas
-os.environ.update({
-    "TELEGRAM_TOKEN": "x",
-    "OPENAI_API_KEY": "x",
-    "NOTION_TOKEN": "x",
-    "NOTION_DATABASE_ID": "x",
-    "DB_USER": "u",
-    "DB_PASSWORD": "p",
-    "SLACK_WEBHOOK_URL": "x",
-    "SUPERVISOR_DB_ID": "x",
-    "SMTP_HOST": "smtp.example.com",
-    "SMTP_PORT": "25",
-    "SMTP_USER": "bot@example.com",
-    "SMTP_PASSWORD": "pwd",
-    "SMTP_USE_TLS": "true",
-})
+os.environ.update(
+    {
+        "TELEGRAM_TOKEN": "x",
+        "OPENAI_API_KEY": "x",
+        "NOTION_TOKEN": "x",
+        "NOTION_DATABASE_ID": "x",
+        "DB_USER": "u",
+        "DB_PASSWORD": "p",
+        "SLACK_WEBHOOK_URL": "x",
+        "SUPERVISOR_DB_ID": "x",
+        "SMTP_HOST": "smtp.example.com",
+        "SMTP_PORT": "25",
+        "SMTP_USER": "bot@example.com",
+        "SMTP_PASSWORD": "pwd",
+        "SMTP_USE_TLS": "true",
+    }
+)
 
 config_mod = importlib.import_module("sandybot.config")
 email_utils = importlib.reload(importlib.import_module("sandybot.email_utils"))
@@ -74,13 +91,16 @@ def test_enviar_excel_por_correo_compatibilidad(tmp_path, monkeypatch):
     # Eliminar variables SMTP para forzar el uso de EMAIL_*
     for var in ["SMTP_HOST", "SMTP_PORT", "SMTP_USER", "SMTP_PASSWORD"]:
         os.environ.pop(var, None)
-    os.environ.update({
-        "EMAIL_HOST": "smtp.legacy.com",
-        "EMAIL_PORT": "26",
-        "EMAIL_USER": "old@example.com",
-        "EMAIL_PASSWORD": "oldpwd",
-    })
+    os.environ.update(
+        {
+            "EMAIL_HOST": "smtp.legacy.com",
+            "EMAIL_PORT": "26",
+            "EMAIL_USER": "old@example.com",
+            "EMAIL_PASSWORD": "oldpwd",
+        }
+    )
     import importlib
+
     config_mod.Config._instance = None
     importlib.reload(config_mod)
     importlib.reload(email_utils)
@@ -92,3 +112,24 @@ def test_enviar_excel_por_correo_compatibilidad(tmp_path, monkeypatch):
     assert reg["host"] == "smtp.legacy.com"
     assert reg["port"] == 26
     assert reg["login"] == ("old@example.com", "oldpwd")
+
+
+def test_generar_nombres(tmp_path):
+    email_utils.config.ARCHIVO_CONTADOR = tmp_path / "cont.json"
+    nombre1 = email_utils.generar_nombre_camaras(5)
+    nombre2 = email_utils.generar_nombre_camaras(5)
+    hoy = datetime.now().strftime("%d%m%Y")
+    assert nombre1 == f"Camaras_5_{hoy}_01"
+    assert nombre2 == f"Camaras_5_{hoy}_02"
+
+
+def test_enviar_tracking_reciente_por_correo(tmp_path):
+    email_utils.config.HISTORICO_DIR = tmp_path
+    (tmp_path / "tracking_7_20240101_000000.txt").write_text("a")
+    reciente = tmp_path / "tracking_7_20240102_000000.txt"
+    reciente.write_text("b")
+    email_utils.config.ARCHIVO_CONTADOR = tmp_path / "cont.json"
+    reg.clear()
+    ok = email_utils.enviar_tracking_reciente_por_correo("d@x.com", 7)
+    assert ok is True
+    assert reg["sent"] is True


### PR DESCRIPTION
## Summary
- cambia `correo.enviar_email` para aceptar `nombre_adjunto`
- genera nombres con contador diario
- usa el nombre al enviar cámaras por chat y por email
- agrega función para mandar el tracking más reciente
- actualiza documentación y pruebas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684853467a108330a91fde75c2346b75