### PR TITLE
Mejoras en asociacion de trackings

### DIFF
--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -83,12 +83,30 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         context.user_data["id_servicio"] = context.user_data.get("id_servicio_detected")
         context.user_data.pop("confirmar_id", None)
         registrar_conversacion(user_id, "confirmar_tracking", "Confirmar ID", "callback")
-        await guardar_tracking_servicio(update, context)
+        keyboard = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton("Principal", callback_data="tracking_principal"),
+                    InlineKeyboardButton("Complementario", callback_data="tracking_complementario"),
+                ]
+            ]
+        )
+        await query.edit_message_text(
+            "¿El tracking es principal o complementario?",
+            reply_markup=keyboard,
+        )
 
     elif query.data == "cambiar_id_tracking":
         context.user_data["confirmar_id"] = True
         registrar_conversacion(query.from_user.id, "cambiar_id_tracking", "Solicitar ID", "callback")
         await query.edit_message_text("Escribí el ID correcto.")
+
+    elif query.data in ("tracking_principal", "tracking_complementario"):
+        context.user_data["tipo_tracking"] = (
+            "principal" if query.data == "tracking_principal" else "complementario"
+        )
+        registrar_conversacion(query.from_user.id, query.data, "Elegir tipo", "callback")
+        await guardar_tracking_servicio(update, context)
 
     elif query.data == "informe_sla":
         registrar_conversacion(query.from_user.id, "informe_sla", "No implementado", "callback")

--- a/Sandy bot/sandybot/handlers/cargar_tracking.py
+++ b/Sandy bot/sandybot/handlers/cargar_tracking.py
@@ -5,7 +5,7 @@ import logging
 import re
 from pathlib import Path
 from datetime import datetime
-from ..utils import obtener_mensaje
+from ..utils import obtener_mensaje, normalizar_camara
 from ..tracking_parser import TrackingParser
 from ..config import config
 from ..database import actualizar_tracking, obtener_servicio, crear_servicio
@@ -130,6 +130,27 @@ async def guardar_tracking_servicio(update: Update, context: ContextTypes.DEFAUL
         )
         return
 
+    if "tipo_tracking" not in context.user_data:
+        keyboard = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton("Principal", callback_data="tracking_principal"),
+                    InlineKeyboardButton(
+                        "Complementario", callback_data="tracking_complementario"
+                    ),
+                ]
+            ]
+        )
+        await responder_registrando(
+            mensaje,
+            user_id,
+            "seleccionar_tipo",
+            "Seleccioná el tipo del tracking.",
+            "cargar_tracking",
+        )
+        await mensaje.reply_text("¿El tracking es principal o complementario?", reply_markup=keyboard)
+        return
+
     ruta_destino = config.DATA_DIR / f"tracking_{servicio}.txt"
     rutas_extra = []
     if ruta_destino.exists():
@@ -147,9 +168,33 @@ async def guardar_tracking_servicio(update: Update, context: ContextTypes.DEFAUL
         camaras = parser._data[0][1]["camara"].astype(str).tolist()
         rutas_extra.append(str(ruta_destino))
         id_servicio = int(servicio)
-        if not obtener_servicio(id_servicio):
+        existente = obtener_servicio(id_servicio)
+        if not existente:
             crear_servicio(id=id_servicio)
-        actualizar_tracking(id_servicio, str(ruta_destino), camaras, rutas_extra)
+            cam_anterior = []
+        else:
+            cam_anterior = existente.camaras or []
+
+        nuevas = {normalizar_camara(c) for c in camaras}
+        anteriores = {normalizar_camara(c) for c in cam_anterior}
+        if nuevas == anteriores:
+            await responder_registrando(
+                mensaje,
+                user_id,
+                f"tracking_{servicio}.txt",
+                "Sin diferencias con el último tracking. Se omitió la carga.",
+                "cargar_tracking",
+            )
+            return
+
+        tipo = context.user_data.pop("tipo_tracking", "principal")
+        actualizar_tracking(
+            id_servicio,
+            str(ruta_destino),
+            camaras,
+            rutas_extra,
+            tipo=tipo,
+        )
         await responder_registrando(
             mensaje,
             user_id,

--- a/Sandy bot/sandybot/handlers/ingresos.py
+++ b/Sandy bot/sandybot/handlers/ingresos.py
@@ -287,7 +287,11 @@ async def procesar_ingresos(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             "ingresos",
         )
 
-        actualizar_tracking(int(id_servicio), trackings_txt=[str(destino)])
+        actualizar_tracking(
+            int(id_servicio),
+            trackings_txt=[str(destino)],
+            tipo="complementario",
+        )
 
         UserState.set_mode(user_id, "")
         context.user_data.pop("id_servicio", None)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -134,23 +134,26 @@ def test_exportar_camaras_servicio_cadena(tmp_path):
 
 def test_actualizar_tracking_jsonb():
     servicio = bd.crear_servicio(nombre="S6", cliente="F")
-    bd.actualizar_tracking(servicio.id, "ruta.txt", ["C1"], ["t1.txt"])
+    bd.actualizar_tracking(servicio.id, "ruta.txt", ["C1"], ["t1.txt"], tipo="principal")
 
     with bd.SessionLocal() as s:
         reg = s.get(bd.Servicio, servicio.id)
         assert reg.ruta_tracking == "ruta.txt"
         assert reg.camaras == ["C1"]
-        assert reg.trackings == ["t1.txt"]
+        assert isinstance(reg.trackings[0], dict)
+        assert reg.trackings[0]["ruta"] == "t1.txt"
+        assert reg.trackings[0]["tipo"] == "principal"
 
 
 def test_actualizar_tracking_string():
     """Verifica que se actualice si el campo ``trackings`` quedó como texto."""
     servicio = bd.crear_servicio(nombre="S7", cliente="G", trackings="[]")
-    bd.actualizar_tracking(servicio.id, trackings_txt=["nuevo.txt"])
+    bd.actualizar_tracking(servicio.id, trackings_txt=["nuevo.txt"], tipo="complementario")
 
     with bd.SessionLocal() as s:
         reg = s.get(bd.Servicio, servicio.id)
-        assert reg.trackings == ["nuevo.txt"]
+        assert reg.trackings[0]["ruta"] == "nuevo.txt"
+        assert reg.trackings[0]["tipo"] == "complementario"
 
 
 def test_crear_ingreso():


### PR DESCRIPTION
## Summary
- permite registrar tipo de tracking y registrar diferencias
- agrega seleccion de tipo principal o complementario al cargar
- evita guardar trackings sin cambios
- usa el nuevo esquema en handlers y pruebas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848602ca9888330806ef783a3ccd489