### PR TITLE
Inicialización de BD controlada en main.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ Se incluyen dos modelos principales:
    También guarda la ruta del informe de comparación, los trackings
    asociados y las cámaras involucradas en cada servicio.
 
-Al iniciar el bot, `init_db()` crea las tablas de forma automática y
-ejecuta `ensure_servicio_columns()` para garantizar que la tabla
-`servicios` incluya las columnas `ruta_tracking`, `trackings`, `camaras`,
-`carrier` e `id_carrier`.
+Antes de crear la instancia del bot se ejecuta `init_db()` desde
+`main.py`. Esta función crea las tablas y ejecuta
+`ensure_servicio_columns()` para garantizar que la tabla `servicios`
+incluya las columnas `ruta_tracking`, `trackings`, `camaras`, `carrier` e
+`id_carrier`.
 
 Para aprovechar las búsquedas acentuadas se utilizan las extensiones
 `unaccent` y `pg_trgm`.  El usuario configurado en la base debe tener

--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -6,12 +6,13 @@ Bot de Telegram para gestión de infraestructura de fibra óptica.
 
 - Integración con Telegram usando python-telegram-bot
 - Procesamiento de lenguaje natural con GPT-4
-- Base de datos PostgreSQL para historial de conversaciones
-- `init_db()` crea las tablas y ejecuta `ensure_servicio_columns()`
-  para verificar que la tabla `servicios` incluya las columnas
-  `ruta_tracking`, `trackings`, `camaras`, `carrier` e `id_carrier`.
-  Ahora `camaras` y `trackings` usan `JSONB` y guardan listas sin
-  convertirlas a texto
+- Base de datos PostgreSQL para historial de conversaciones.
+- `init_db()` se ejecuta desde `main.py` para crear las tablas y
+  ejecutar `ensure_servicio_columns()`. Esto verifica que la tabla
+  `servicios` incluya las columnas `ruta_tracking`, `trackings`,
+  `camaras`, `carrier` e `id_carrier`. Las columnas de cámaras y
+  trackings utilizan `JSONB` y permiten guardar listas sin convertirlas a
+  texto
 - Procesamiento de archivos Excel para informes
 - Generación de documentos Word
 - Integración con Notion para seguimiento de solicitudes
@@ -111,12 +112,12 @@ sandybot/
 
 ## Modelos de base de datos
 
-La función `init_db()` crea las tablas automáticamente y ejecuta
-`ensure_servicio_columns()` para asegurar que la tabla `servicios`
-contenga las columnas `ruta_tracking`, `trackings`, `camaras`, `carrier`
-e `id_carrier`.
-Las columnas de cámaras y trackings se guardan como `JSONB` para
-admitir listas sin procesamiento adicional.
+La función `init_db()` se ejecuta al inicio desde `main.py` para crear las
+tablas y llamar a `ensure_servicio_columns()`. Esto garantiza que la tabla
+`servicios` incluya las columnas `ruta_tracking`, `trackings`, `camaras`,
+`carrier` e `id_carrier`. Las cámaras y los trackings se almacenan como
+`JSONB`, por lo que se admiten listas de forma nativa sin procesamiento
+adicional.
 
 - **Conversacion**: guarda los mensajes del bot y las respuestas.
 - **Servicio**: almacena nombre, cliente, carrier e ID carrier, además

--- a/Sandy bot/main.py
+++ b/Sandy bot/main.py
@@ -6,6 +6,7 @@ import sys
 import os
 from sandybot.bot import SandyBot
 from sandybot.logging_config import setup_logging
+from sandybot.database import init_db
 
 # Configurar la consola para usar UTF-8 en Windows
 if os.name == 'nt':
@@ -18,6 +19,7 @@ setup_logging()
 def main():
     """Función principal que inicia el bot"""
     try:
+        init_db()
         bot = SandyBot()
         bot.run()
     except Exception as e:

--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -187,8 +187,9 @@ def init_db():
                 )
 
 
-# Crear las tablas al importar el módulo
-init_db()
+
+# La inicialización se realiza desde ``main.py`` para evitar errores al
+# importar el módulo cuando la base de datos no está disponible.
 
 
 def obtener_servicio(id_servicio: int) -> Servicio | None:


### PR DESCRIPTION
## Summary
- quitar `init_db()` de `database.py`
- inicializar la base desde `main.py` antes de crear el bot
- actualizar los README con el nuevo proceso

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848676fa1108330acec197e650d03e6