### PR TITLE
Elimina caracter oculto en handler

### DIFF
--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -138,7 +138,7 @@ async def message_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await guardar_registro(update, context)
             return
 
-        # Activar modo Sandy si no está activo␊
+        # Activar modo Sandy si no está activo
         if not mode:
             UserState.set_mode(user_id, "sandy")
 


### PR DESCRIPTION
## Resumen
- quita el caracter `␊` en `message.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486773041083309052ec338060b1e9