### PR TITLE
Ajuste de debug SMTP

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -57,6 +57,7 @@ def enviar_correo(
     *,
     host: str | None = None,
     port: int | None = None,
+    debug: bool | None = None,
 ) -> bool:
     """Envía un correo simple a los destinatarios almacenados."""
     correos = cargar_destinatarios(ruta_dest)
@@ -69,7 +70,13 @@ def enviar_correo(
     msg = f"Subject: {asunto}\n\n{cuerpo}"
     try:
         with smtplib.SMTP(host, port) as smtp:
-            smtp.set_debuglevel(1)
+            activar_debug = (
+                debug
+                if debug is not None
+                else os.getenv("SMTP_DEBUG", "0").lower() in {"1", "true", "yes"}
+            )
+            if activar_debug:
+                smtp.set_debuglevel(1)
             smtp.sendmail(config.EMAIL_FROM or config.SMTP_USER, correos, msg)
         return True
     except Exception as e:  # pragma: no cover - depende del entorno

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -90,10 +90,33 @@ def test_enviar_correo(monkeypatch, tmp_path):
 
     monkeypatch.setattr(email_utils.smtplib, "SMTP", DebugSMTP)
 
-    ok = email_utils.enviar_correo("Alerta", "Prueba", json_path, host="localhost", port=1025)
+    os.environ.pop("SMTP_DEBUG", None)
+    registros.clear()
+
+    ok = email_utils.enviar_correo(
+        "Alerta",
+        "Prueba",
+        json_path,
+        host="localhost",
+        port=1025,
+    )
 
     assert ok is True
     assert registros["host"] == "localhost"
     assert registros["port"] == 1025
+    assert "debug" not in registros
+
+    os.environ["SMTP_DEBUG"] = "1"
+    registros.clear()
+
+    ok = email_utils.enviar_correo(
+        "Alerta",
+        "Prueba",
+        json_path,
+        host="localhost",
+        port=1025,
+    )
+
     assert registros["debug"] == 1
     assert registros["sent"][0][1] == ["c@x.com"]
+    os.environ.pop("SMTP_DEBUG", None)


### PR DESCRIPTION
## Cambios realizados
- `enviar_correo` ahora acepta un parámetro `debug` y verifica la variable de entorno `SMTP_DEBUG` para activar `set_debuglevel(1)`.
- Se actualizó la prueba `test_enviar_correo` para comprobar el nuevo comportamiento condicional.

## Pruebas
- `setup_env.sh` para instalar dependencias.
- `pytest -q` ejecutado con éxito: todos los tests pasan.

------
https://chatgpt.com/codex/tasks/task_e_6848677595ac8330a4ce3626c72a778c