### PR TITLE
Ajuste SMTP_USE_TLS booleano

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ El comportamiento de SandyBot se ajusta mediante varias variables de entorno:
 - `GPT_MODEL`: modelo de OpenAI a emplear. Por defecto se aplica `gpt-4`.
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`: datos para el servidor
   de correo saliente.
-- `SMTP_USE_TLS`: si vale `false` o se usa el puerto 465 se emplea
-  `SMTP_SSL`; en los demás casos se inicia TLS con `starttls()`.
+- `SMTP_USE_TLS`: controla si se inicia TLS. Si se define como `false` o se usa
+  el puerto 465 se emplea `SMTP_SSL`; en caso contrario se ejecuta `starttls()`.
 - También se aceptan `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_USER` y
   `EMAIL_PASSWORD` para mantener compatibilidad con versiones antiguas.
 

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -111,8 +111,8 @@ class Config:
         self.SMTP_PASSWORD = smtp_pwd
         self.EMAIL_FROM = os.getenv("EMAIL_FROM")
 
-        # Uso de TLS
-        self.SMTP_USE_TLS = os.getenv("SMTP_USE_TLS", "true")
+        # Uso de TLS como booleano
+        self.SMTP_USE_TLS = os.getenv("SMTP_USE_TLS", "true").lower() != "false"
 
         # Alias de compatibilidad
         self.EMAIL_HOST = self.SMTP_HOST

--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -115,12 +115,13 @@ def enviar_excel_por_correo(
         smtp_host = os.getenv("SMTP_HOST", getattr(config, "EMAIL_HOST", ""))
         smtp_port = int(os.getenv("SMTP_PORT", getattr(config, "EMAIL_PORT", 0)))
         smtp_pwd = os.getenv("SMTP_PASSWORD", getattr(config, "EMAIL_PASSWORD", ""))
-        use_tls = (
-            os.getenv(
-                "SMTP_USE_TLS", str(getattr(config, "SMTP_USE_TLS", True))
-            ).lower()
-            != "false"
-        )
+
+        # Prioridad: variable de entorno o valor de config
+        use_tls_env = os.getenv("SMTP_USE_TLS")
+        if use_tls_env is None:
+            use_tls = getattr(config, "SMTP_USE_TLS", True)
+        else:
+            use_tls = use_tls_env.lower() != "false"
 
         msg["From"] = smtp_user or getattr(config, "EMAIL_FROM", "")
 

--- a/Sandy bot/sandybot/handlers/enviar_camaras_mail.py
+++ b/Sandy bot/sandybot/handlers/enviar_camaras_mail.py
@@ -38,7 +38,7 @@ def _enviar_mail(destino: str, archivo: str, nombre: str) -> None:
     servidor = config.SMTP_HOST or "localhost"
     puerto = config.SMTP_PORT
 
-    usar_tls = str(config.SMTP_USE_TLS).lower() != "false"
+    usar_tls = config.SMTP_USE_TLS
     usar_ssl = not usar_tls or puerto == 465
 
     if usar_ssl:


### PR DESCRIPTION
## Summary
- tratar la variable `SMTP_USE_TLS` como booleana al cargarla
- respetar el valor booleano al enviar correos
- simplificar la lógica de TLS en el handler de cámaras
- aclarar el comportamiento en el README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848677972848330a55aacfaa81162b6