### PR TITLE
Add global OpenAI client for voice handler

### DIFF
--- a/Sandy bot/sandybot/handlers/voice.py
+++ b/Sandy bot/sandybot/handlers/voice.py
@@ -11,6 +11,9 @@ from .message import message_handler
 
 logger = logging.getLogger(__name__)
 
+# Cliente global de OpenAI para transcribir audios
+voice_client = openai.AsyncOpenAI(api_key=config.OPENAI_API_KEY)
+
 async def voice_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Descarga el audio, lo transcribe y pasa el texto a ``message_handler``."""
     mensaje = update.message
@@ -23,8 +26,7 @@ async def voice_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     try:
         await voice.download_to_drive(path)
         with open(path, "rb") as audio:
-            client = openai.AsyncOpenAI(api_key=config.OPENAI_API_KEY)
-            transcripcion = await client.audio.transcriptions.create(
+            transcripcion = await voice_client.audio.transcriptions.create(
                 file=audio,
                 model="whisper-1",
             )

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -139,6 +139,7 @@ sys.modules.setdefault("sandybot.handlers", handlers_pkg)
 config_mod = importlib.import_module("sandybot.config")
 voice_module = importlib.import_module("sandybot.handlers.voice")
 voice_module.message_handler = message_handler
+voice_module.voice_client = openai_stub.AsyncOpenAI()
 
 # Restaurar el módulo ``openai`` para no interferir con la colección
 if openai_original is not None:
@@ -150,8 +151,10 @@ else:
 def test_voice_no_modifica_update():
     upd = Update(message=Message(voice=Voice()))
     ctx = SimpleNamespace(user_data={})
+    cliente = voice_module.voice_client
     asyncio.run(voice_module.voice_handler(upd, ctx))
     assert captura["texto"] == "texto voz"
     assert captura["original"] is None
     assert upd.message.text is None
     assert ctx.user_data == {}
+    assert voice_module.voice_client is cliente


### PR DESCRIPTION
## Summary
- create a persistent OpenAI client in `voice.py`
- use the global client inside `voice_handler`
- update `tests/test_voice_handler.py` to set and verify the global client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486f6029ac833094bca55d1c4794ed