### PR TITLE
Añade índice id_carrier y pruebas

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -86,7 +86,7 @@ class Servicio(Base):
     camaras = Column(JSONType)
 
     carrier = Column(String)
-    id_carrier = Column(String)
+    id_carrier = Column(String, index=True)
     fecha_creacion = Column(DateTime, default=datetime.utcnow, index=True)
 
     def __repr__(self):
@@ -141,6 +141,16 @@ def ensure_servicio_columns() -> None:
         with engine.begin() as conn:
             conn.execute(
                 text(f"ALTER TABLE servicios ADD COLUMN {columna} {tipo}")
+            )
+
+    indices = {idx["name"] for idx in inspector.get_indexes("servicios")}
+    if "ix_servicios_id_carrier" not in indices:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE INDEX ix_servicios_id_carrier"
+                    " ON servicios (id_carrier)"
+                )
             )
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -176,3 +176,22 @@ def test_registrar_servicio_merge():
         assert len(filas) == 1
         assert filas[0].id_carrier == "c1"
 
+
+def test_ensure_servicio_columns_crea_indice():
+    """Verifica que ``ensure_servicio_columns`` genere el índice."""
+
+    with bd.engine.begin() as conn:
+        conn.execute(text("DROP INDEX IF EXISTS ix_servicios_id_carrier"))
+
+    insp = sqlalchemy.inspect(bd.engine)
+    assert not any(
+        i["name"] == "ix_servicios_id_carrier" for i in insp.get_indexes("servicios")
+    )
+
+    bd.ensure_servicio_columns()
+
+    insp = sqlalchemy.inspect(bd.engine)
+    assert any(
+        i["name"] == "ix_servicios_id_carrier" for i in insp.get_indexes("servicios")
+    )
+


### PR DESCRIPTION
## Resumen
- se marca `id_carrier` con `index=True`
- `ensure_servicio_columns` ahora crea el índice si falta
- se agrega una prueba que valida la creación automática del índice

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c89c6060833099890ef128f3c4b9