### PR TITLE
Implementación de clientes y destinatarios en DB

### DIFF
--- a/Sandy bot/sandybot/handlers/descargar_camaras.py
+++ b/Sandy bot/sandybot/handlers/descargar_camaras.py
@@ -6,7 +6,7 @@ import logging
 import os
 import tempfile
 
-from ..utils import obtener_mensaje, cargar_json
+from ..utils import obtener_mensaje
 from ..database import exportar_camaras_servicio
 from ..registrador import (
     responder_registrando,
@@ -14,7 +14,6 @@ from ..registrador import (
     registrar_envio_email,
 )
 from ..correo import enviar_email
-from ..config import config
 from .estado import UserState
 
 logger = logging.getLogger(__name__)
@@ -87,11 +86,10 @@ async def enviar_camaras_servicio(
             "descargar_camaras",
         )
 
-        # Cargar los destinatarios desde el JSON configurado y enviar el
-        # mismo archivo por correo. Si el envío es exitoso se registra en la
-        # base de conversaciones para mantener un historial.
-        data = cargar_json(config.ARCHIVO_DESTINATARIOS)
-        destinatarios = data.get("emails", []) if isinstance(data, dict) else []
+        # Obtener destinatarios del cliente asociado al servicio
+        from ..database import obtener_destinatarios_servicio
+
+        destinatarios = obtener_destinatarios_servicio(id_servicio)
         if destinatarios:
             if enviar_email(
                 destinatarios,

--- a/Sandy bot/sandybot/handlers/destinatarios.py
+++ b/Sandy bot/sandybot/handlers/destinatarios.py
@@ -2,85 +2,94 @@
 
 from telegram import Update
 from telegram.ext import ContextTypes
-from ..utils import cargar_json, guardar_json, obtener_mensaje
-from ..config import config
+from ..utils import obtener_mensaje
 from ..registrador import responder_registrando
+from ..database import SessionLocal, Cliente, obtener_cliente_por_nombre
 
 ARCH_KEY = "destinatarios"
 
 async def agregar_destinatario(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Agrega un destinatario al archivo JSON"""
+    """Agrega un destinatario para un cliente en la base"""
     mensaje = obtener_mensaje(update)
     if not mensaje:
         return
     user_id = update.effective_user.id
-    texto = " ".join(context.args) if context.args else ""
-    if not texto:
+    if len(context.args) < 2:
         await responder_registrando(
             mensaje,
             user_id,
             mensaje.text or "agregar_destinatario",
-            "Indicá el destinatario después del comando.",
+            "Usá: /agregar_destinatario <cliente> <correo>",
             "destinatarios",
         )
         return
-    datos = cargar_json(config.ARCHIVO_DESTINATARIOS)
-    lista = datos.get(ARCH_KEY, [])
-    if texto in lista:
-        await responder_registrando(
-            mensaje,
-            user_id,
-            mensaje.text,
-            f"{texto} ya está registrado.",
-            "destinatarios",
-        )
-        return
-    lista.append(texto)
-    datos[ARCH_KEY] = lista
-    guardar_json(datos, config.ARCHIVO_DESTINATARIOS)
+    cliente = context.args[0]
+    correo = context.args[1]
+    with SessionLocal() as session:
+        cli = obtener_cliente_por_nombre(cliente)
+        if not cli:
+            cli = Cliente(nombre=cliente, destinatarios=[correo])
+            session.add(cli)
+            session.commit()
+        else:
+            lista = cli.destinatarios or []
+            if correo in lista:
+                await responder_registrando(
+                    mensaje,
+                    user_id,
+                    mensaje.text,
+                    f"{correo} ya está registrado para {cliente}.",
+                    "destinatarios",
+                )
+                return
+            lista.append(correo)
+            cli.destinatarios = lista
+            session.commit()
     await responder_registrando(
         mensaje,
         user_id,
         mensaje.text,
-        f"Destinatario {texto} agregado correctamente.",
+        f"Destinatario {correo} agregado para {cliente}.",
         "destinatarios",
     )
 
 async def eliminar_destinatario(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Elimina un destinatario del JSON"""
+    """Elimina un destinatario de un cliente"""
     mensaje = obtener_mensaje(update)
     if not mensaje:
         return
     user_id = update.effective_user.id
-    texto = " ".join(context.args) if context.args else ""
-    if not texto:
+    if len(context.args) < 2:
         await responder_registrando(
             mensaje,
             user_id,
             mensaje.text or "eliminar_destinatario",
-            "Indicá el destinatario a borrar.",
+            "Usá: /eliminar_destinatario <cliente> <correo>",
             "destinatarios",
         )
         return
-    datos = cargar_json(config.ARCHIVO_DESTINATARIOS)
-    lista = datos.get(ARCH_KEY, [])
-    if texto not in lista:
-        await responder_registrando(
-            mensaje,
-            user_id,
-            mensaje.text,
-            f"{texto} no está en la lista.",
-            "destinatarios",
-        )
-        return
-    lista.remove(texto)
-    datos[ARCH_KEY] = lista
-    guardar_json(datos, config.ARCHIVO_DESTINATARIOS)
+    cliente = context.args[0]
+    correo = context.args[1]
+    with SessionLocal() as session:
+        cli = obtener_cliente_por_nombre(cliente)
+        if not cli or correo not in (cli.destinatarios or []):
+            await responder_registrando(
+                mensaje,
+                user_id,
+                mensaje.text,
+                f"{correo} no está en la lista de {cliente}.",
+                "destinatarios",
+            )
+            return
+        lista = cli.destinatarios or []
+        lista.remove(correo)
+        cli.destinatarios = lista
+        session.commit()
     await responder_registrando(
         mensaje,
         user_id,
         mensaje.text,
-        f"Destinatario {texto} eliminado.",
+        f"Destinatario {correo} eliminado de {cliente}.",
         "destinatarios",
     )
 
@@ -90,12 +99,23 @@ async def listar_destinatarios(update: Update, context: ContextTypes.DEFAULT_TYP
     if not mensaje:
         return
     user_id = update.effective_user.id
-    datos = cargar_json(config.ARCHIVO_DESTINATARIOS)
-    lista = datos.get(ARCH_KEY, [])
+    if not context.args:
+        await responder_registrando(
+            mensaje,
+            user_id,
+            mensaje.text or "listar_destinatarios",
+            "Indicá el nombre del cliente.",
+            "destinatarios",
+        )
+        return
+    cliente = context.args[0]
+    with SessionLocal() as session:
+        cli = obtener_cliente_por_nombre(cliente)
+        lista = cli.destinatarios if cli and cli.destinatarios else []
     if not lista:
-        respuesta = "No hay destinatarios registrados."
+        respuesta = f"No hay destinatarios registrados para {cliente}."
     else:
-        respuesta = "Destinatarios registrados:\n" + "\n".join(f"- {d}" for d in lista)
+        respuesta = f"Destinatarios de {cliente}:\n" + "\n".join(f"- {d}" for d in lista)
     await responder_registrando(
         mensaje,
         user_id,


### PR DESCRIPTION
## Summary
- nueva tabla `Cliente` y vínculo con `Servicio`
- funciones para obtener destinatarios según cliente
- actualización de handlers para manipular correos en la base
- envío de cámaras por correo usando los destinatarios del cliente
- pruebas ampliadas para clientes y correos asociados

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d00e84308330b77e0e8ecfdaa76d