### PR TITLE
Implementa tareas programadas y avisos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 logs/
+.venv/

--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -31,6 +31,7 @@ from .handlers import (
     agregar_destinatario,
     eliminar_destinatario,
     listar_destinatarios,
+    registrar_tarea_programada,
 )
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,9 @@ class SandyBot:
         )
         self.app.add_handler(
             CommandHandler("listar_destinatarios", listar_destinatarios)
+        )
+        self.app.add_handler(
+            CommandHandler("registrar_tarea", registrar_tarea_programada)
         )
 
         # Callbacks de botones

--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from email.message import EmailMessage
 
 from .config import config
-from .database import SessionLocal, Cliente
+from .database import SessionLocal, Cliente, Servicio, TareaProgramada
 from .utils import (
     cargar_destinatarios as utils_cargar_dest,
     guardar_destinatarios as utils_guardar,
@@ -228,3 +228,31 @@ def enviar_tracking_reciente_por_correo(
     from .correo import enviar_email
 
     return enviar_email([destinatario], asunto, cuerpo, ruta, nombre)
+
+
+def generar_archivo_msg(
+    tarea: TareaProgramada,
+    cliente: Cliente,
+    servicios: list[Servicio],
+    ruta: str,
+) -> str:
+    """Crea un archivo .MSG simple con la información de la tarea."""
+
+    lineas = [
+        "Estimado Cliente, nuestro partner nos da aviso de la siguiente tarea programada:",
+        f"Inicio: {tarea.fecha_inicio}",
+        f"Fin: {tarea.fecha_fin}",
+        f"Tipo de tarea: {tarea.tipo_tarea}",
+    ]
+    if tarea.tiempo_afectacion:
+        lineas.append(f"Tiempo de afectaci\u00f3n: {tarea.tiempo_afectacion}")
+    if tarea.descripcion:
+        lineas.append(f"Descripci\u00f3n: {tarea.descripcion}")
+
+    lista_servicios = ", ".join(str(s.id) for s in servicios)
+    lineas.append(f"Servicios afectados: {lista_servicios}")
+
+    contenido = "\n".join(lineas)
+    with open(ruta, "w", encoding="utf-8") as f:
+        f.write(contenido)
+    return ruta

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -24,6 +24,7 @@ from .destinatarios import (
     eliminar_destinatario,
     listar_destinatarios,
 )
+from .tarea_programada import registrar_tarea_programada
 
 __all__ = [
     'start_handler',
@@ -54,4 +55,5 @@ __all__ = [
     'agregar_destinatario',
     'eliminar_destinatario',
     'listar_destinatarios'
+    , 'registrar_tarea_programada'
 ]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -226,3 +226,17 @@ def test_cliente_destinatarios():
         dest = bd.obtener_destinatarios_servicio(servicio.id)
         assert dest == ["a@x.com"]
 
+
+def test_crear_tarea_y_relacion():
+    s = bd.crear_servicio(nombre="Srv", cliente="Cli")
+    tarea = bd.crear_tarea_programada(
+        datetime(2024, 1, 1, 8),
+        datetime(2024, 1, 1, 10),
+        "Mantenimiento",
+        [s.id],
+        tiempo_afectacion="2h",
+    )
+    tareas = bd.obtener_tareas_servicio(s.id)
+    assert len(tareas) == 1
+    assert tareas[0].id == tarea.id
+


### PR DESCRIPTION
## Notas
- Se agregó `.venv/` al `.gitignore` para evitar incluir el entorno virtual.

## Cambios principales
- Nuevos modelos `TareaProgramada` y `TareaServicio` en la base de datos. Permiten registrar tareas de mantenimiento y vincular los servicios afectados.
- Se añadieron las funciones `crear_tarea_programada` y `obtener_tareas_servicio`.
- `email_utils` incorpora `generar_archivo_msg` para producir un archivo `.msg` básico con la información de la tarea.
- Nuevo handler `registrar_tarea_programada` accesible mediante `/registrar_tarea`.
- `bot.py` registra el nuevo comando.
- Pruebas actualizadas y añadidas para cubrir la nueva funcionalidad.

## Pruebas
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68488a9f34488330b787988e70e52d39