### PR TITLE
Añade restricción única en TareaServicio

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -240,3 +240,19 @@ def test_crear_tarea_y_relacion():
     assert len(tareas) == 1
     assert tareas[0].id == tarea.id
 
+
+def test_tarea_servicio_unica():
+    """La relación tarea-servicio no debe duplicarse."""
+
+    s = bd.crear_servicio(nombre="SrvU", cliente="CliU")
+    tarea = bd.crear_tarea_programada(
+        datetime(2024, 1, 2, 8),
+        datetime(2024, 1, 2, 10),
+        "Mantenimiento",
+        [s.id],
+    )
+    with pytest.raises(sqlalchemy.exc.IntegrityError):
+        with bd.SessionLocal() as session:
+            session.add(bd.TareaServicio(tarea_id=tarea.id, servicio_id=s.id))
+            session.commit()
+


### PR DESCRIPTION
## Resumen
- se agrega `UniqueConstraint` sobre `(tarea_id, servicio_id)` en `TareaServicio`
- `ensure_servicio_columns` ahora crea la restricción si falta
- se añade prueba que confirma que la relación no se duplica

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d6c0dadc83308de90cb1c0870bdb