### PR TITLE
Añade índice compuesto en tareas programadas

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     func,
     JSON,
     ForeignKey,
+    Index,
 )
 from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy.dialects.postgresql import JSONB
@@ -149,6 +150,13 @@ class TareaProgramada(Base):
     descripcion = Column(String)
 
 
+Index(
+    "ix_tareas_programadas_fecha_inicio_fecha_fin",
+    TareaProgramada.fecha_inicio,
+    TareaProgramada.fecha_fin,
+)
+
+
 class TareaServicio(Base):
     """Servicios afectados por cada :class:`TareaProgramada`."""
 
@@ -201,6 +209,16 @@ def ensure_servicio_columns() -> None:
                 text(
                     "CREATE INDEX ix_servicios_cliente_id"
                     " ON servicios (cliente_id)"
+                )
+            )
+
+    indices_tareas = {idx["name"] for idx in inspector.get_indexes("tareas_programadas")}
+    if "ix_tareas_programadas_fecha_inicio_fecha_fin" not in indices_tareas:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE INDEX ix_tareas_programadas_fecha_inicio_fecha_fin"
+                    " ON tareas_programadas (fecha_inicio, fecha_fin)"
                 )
             )
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -240,3 +240,28 @@ def test_crear_tarea_y_relacion():
     assert len(tareas) == 1
     assert tareas[0].id == tarea.id
 
+
+def test_ensure_servicio_columns_indice_tarea_programada():
+    """La función crea el índice combinado de fechas."""
+
+    with bd.engine.begin() as conn:
+        conn.execute(
+            text(
+                "DROP INDEX IF EXISTS ix_tareas_programadas_fecha_inicio_fecha_fin"
+            )
+        )
+
+    insp = sqlalchemy.inspect(bd.engine)
+    assert not any(
+        i["name"] == "ix_tareas_programadas_fecha_inicio_fecha_fin"
+        for i in insp.get_indexes("tareas_programadas")
+    )
+
+    bd.ensure_servicio_columns()
+
+    insp = sqlalchemy.inspect(bd.engine)
+    assert any(
+        i["name"] == "ix_tareas_programadas_fecha_inicio_fecha_fin"
+        for i in insp.get_indexes("tareas_programadas")
+    )
+


### PR DESCRIPTION
## Summary
- actualiza `database.py` importando `Index`
- crea índice `(fecha_inicio, fecha_fin)` en `TareaProgramada`
- genera el índice desde `ensure_servicio_columns`
- prueba que valida la creación usando `sqlalchemy.inspect`

## Testing
- `./setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d6e95f488330bc467d8bf4ade645