### PR TITLE
Agregar SIGNATURE_PATH y soporte opcional para win32

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ El comportamiento de SandyBot se ajusta mediante varias variables de entorno:
 
 - `PLANTILLA_PATH`: ruta de la plantilla para los informes de repetitividad. Si
   no se define, se usa `C:\Metrotel\Sandy\plantilla_informe.docx`.
+- `SIGNATURE_PATH`: ruta a la firma opcional que se agregará en los correos.
 - `GPT_MODEL`: modelo de OpenAI a emplear. Por defecto se aplica `gpt-4`.
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`: datos para el servidor
   de correo saliente.

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -80,6 +80,8 @@ class Config:
             "PLANTILLA_PATH",
             r"C:\\Metrotel\\Sandy\\plantilla_informe.docx"
         )
+        # Firma opcional en correos
+        self.SIGNATURE_PATH = os.getenv("SIGNATURE_PATH")
 
         # Configuración GPT
         # Permite elegir el modelo vía la variable de entorno "GPT_MODEL".

--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -8,6 +8,13 @@ import re
 from datetime import datetime
 from email.message import EmailMessage
 
+try:
+    import win32com.client as win32
+    import pythoncom
+except ImportError:  # pragma: no cover - entornos sin win32
+    win32 = None
+    pythoncom = None
+
 from .config import config
 from .database import SessionLocal, Cliente, Servicio, TareaProgramada
 from .utils import (


### PR DESCRIPTION
## Summary
- permitir ruta de firma en config
- cargar win32 opcionalmente en email_utils
- documentar SIGNATURE_PATH en README

## Testing
- `source setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e1fc7adc83309e111003fef370c8