### PR TITLE
Soporte para generar .msg con Outlook

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -9,6 +9,15 @@ from datetime import datetime
 from email.message import EmailMessage
 
 from .config import config
+
+try:
+    import win32com.client as win32
+except ImportError:  # pragma: no cover - depende del sistema
+    win32 = None
+
+SIGNATURE_PATH = (
+    Path(os.getenv("SIGNATURE_PATH")) if os.getenv("SIGNATURE_PATH") else None
+)
 from .database import SessionLocal, Cliente, Servicio, TareaProgramada
 from .utils import (
     cargar_destinatarios as utils_cargar_dest,
@@ -236,7 +245,11 @@ def generar_archivo_msg(
     servicios: list[Servicio],
     ruta: str,
 ) -> str:
-    """Crea un archivo .MSG simple con la información de la tarea."""
+    """Genera un archivo para notificar una tarea programada.
+
+    Cuando ``win32`` está disponible se crea un verdadero archivo ``.msg`` con
+    Outlook. En caso contrario se escribe texto plano como respaldo.
+    """
 
     lineas = [
         "Estimado Cliente, nuestro partner nos da aviso de la siguiente tarea programada:",
@@ -253,6 +266,24 @@ def generar_archivo_msg(
     lineas.append(f"Servicios afectados: {lista_servicios}")
 
     contenido = "\n".join(lineas)
+
+    if win32 is not None:
+        try:
+            outlook = win32.Dispatch("Outlook.Application")
+            mail = outlook.CreateItem(0)
+            mail.Subject = f"Aviso de tarea programada - {cliente.nombre}"
+            firma = ""
+            if SIGNATURE_PATH and SIGNATURE_PATH.exists():
+                try:
+                    firma = SIGNATURE_PATH.read_text(encoding="utf-8")
+                except Exception as e:  # pragma: no cover - depende del entorno
+                    logger.warning("No se pudo leer la firma: %s", e)
+            mail.Body = contenido + ("\n\n" + firma if firma else "")
+            mail.SaveAs(ruta, 3)
+            return ruta
+        except Exception as e:  # pragma: no cover - depende del entorno
+            logger.error("Error generando archivo MSG: %s", e)
+
     with open(ruta, "w", encoding="utf-8") as f:
         f.write(contenido)
     return ruta


### PR DESCRIPTION
## Summary
- generar archivo MSG con Outlook cuando está disponible
- conservar modo de texto plano si no hay COM

## Testing
- `pip install -q -r 'Sandy bot/requirements.txt'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e1fed05c8330b8e2733a39207637