### PR TITLE
Implementar detección de tareas desde correos

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ tarea = crear_tarea_programada(
 )
 ```
 
+### Detectar tareas desde un correo
+
+Con `/detectar_tarea <cliente>` podés pegar el mail o adjuntar el archivo.
+Sandy utiliza GPT para extraer inicio, fin, tipo y los IDs de servicio.
+Al crear la tarea genera también un `.MSG` con el texto listo para enviar.
+
 ## Carga de tracking
 
 Utilizá el comando `/cargar_tracking` y enviá el archivo `.txt`.

--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -32,6 +32,7 @@ from .handlers import (
     eliminar_destinatario,
     listar_destinatarios,
     registrar_tarea_programada,
+    detectar_tarea_mail,
 )
 
 logger = logging.getLogger(__name__)
@@ -72,6 +73,9 @@ class SandyBot:
         )
         self.app.add_handler(
             CommandHandler("registrar_tarea", registrar_tarea_programada)
+        )
+        self.app.add_handler(
+            CommandHandler("detectar_tarea", detectar_tarea_mail)
         )
 
         # Callbacks de botones

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -25,6 +25,7 @@ from .destinatarios import (
     listar_destinatarios,
 )
 from .tarea_programada import registrar_tarea_programada
+from .detectar_tarea_mail import detectar_tarea_mail
 
 __all__ = [
     'start_handler',
@@ -56,4 +57,5 @@ __all__ = [
     'eliminar_destinatario',
     'listar_destinatarios'
     , 'registrar_tarea_programada'
+    , 'detectar_tarea_mail'
 ]

--- a/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
+++ b/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
@@ -1,0 +1,161 @@
+"""Detección automática de tareas programadas desde correos."""
+
+import logging
+import os
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from ..utils import obtener_mensaje
+from ..gpt_handler import gpt
+from ..database import (
+    crear_tarea_programada,
+    obtener_cliente_por_nombre,
+    Cliente,
+    Servicio,
+    SessionLocal,
+)
+from ..email_utils import generar_archivo_msg
+from ..registrador import responder_registrando
+
+logger = logging.getLogger(__name__)
+
+
+async def detectar_tarea_mail(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Procesa un correo enviado por Telegram y registra la tarea."""
+
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        return
+
+    user_id = update.effective_user.id
+
+    if not context.args:
+        await responder_registrando(
+            mensaje,
+            user_id,
+            mensaje.text or "detectar_tarea_mail",
+            "Usá: /detectar_tarea <cliente> y pegá el correo o adjuntalo como archivo.",
+            "tareas",
+        )
+        return
+
+    cliente_nombre = context.args[0]
+
+    contenido = ""
+    if mensaje.document:
+        archivo = await mensaje.document.get_file()
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            await archivo.download_to_drive(tmp.name)
+            ruta = tmp.name
+        try:
+            contenido = Path(ruta).read_text(encoding="utf-8", errors="ignore")
+        except Exception as e:
+            logger.error("Error leyendo adjunto: %s", e)
+            os.remove(ruta)
+            await responder_registrando(
+                mensaje,
+                user_id,
+                mensaje.document.file_name,
+                "No pude leer el archivo adjunto.",
+                "tareas",
+            )
+            return
+        finally:
+            os.remove(ruta)
+    else:
+        partes = mensaje.text.split(maxsplit=2)
+        if len(partes) < 3:
+            await responder_registrando(
+                mensaje,
+                user_id,
+                mensaje.text or "detectar_tarea_mail",
+                "Pegá el correo completo después del nombre del cliente.",
+                "tareas",
+            )
+            return
+        contenido = partes[2]
+
+    prompt = (
+        "Extraé del siguiente correo los datos de la ventana de mantenimiento y "
+        "devolvé solo un JSON con las claves 'inicio', 'fin', 'tipo', "
+        "'afectacion' e 'ids' (lista de servicios).\n\n"
+        f"Correo:\n{contenido}"
+    )
+
+    esquema = {
+        "type": "object",
+        "properties": {
+            "inicio": {"type": "string"},
+            "fin": {"type": "string"},
+            "tipo": {"type": "string"},
+            "afectacion": {"type": "string"},
+            "ids": {
+                "type": "array",
+                "items": {"type": "integer"},
+            },
+        },
+        "required": ["inicio", "fin", "tipo", "ids"],
+    }
+
+    try:
+        respuesta = await gpt.consultar_gpt(prompt)
+        datos = await gpt.procesar_json_response(respuesta, esquema)
+        if not datos:
+            raise ValueError("JSON inválido")
+    except Exception as e:
+        logger.error("Fallo detectando tarea: %s", e)
+        await responder_registrando(
+            mensaje,
+            user_id,
+            mensaje.text or getattr(mensaje.document, "file_name", ""),
+            "No pude identificar la tarea en el correo.",
+            "tareas",
+        )
+        return
+
+    try:
+        inicio = datetime.fromisoformat(str(datos["inicio"]))
+        fin = datetime.fromisoformat(str(datos["fin"]))
+    except Exception:
+        await responder_registrando(
+            mensaje,
+            user_id,
+            mensaje.text or getattr(mensaje.document, "file_name", ""),
+            "Fechas con formato inválido en el correo.",
+            "tareas",
+        )
+        return
+
+    tipo = datos["tipo"]
+    ids = [int(i) for i in datos.get("ids", [])]
+    afectacion = datos.get("afectacion")
+
+    with SessionLocal() as session:
+        cliente = obtener_cliente_por_nombre(cliente_nombre)
+        if not cliente:
+            cliente = Cliente(nombre=cliente_nombre)
+            session.add(cliente)
+            session.commit()
+            session.refresh(cliente)
+
+        tarea = crear_tarea_programada(inicio, fin, tipo, ids, tiempo_afectacion=afectacion)
+        servicios = [session.get(Servicio, i) for i in ids]
+
+        nombre_arch = f"tarea_{tarea.id}.msg"
+        ruta = Path(tempfile.gettempdir()) / nombre_arch
+        generar_archivo_msg(tarea, cliente, [s for s in servicios if s], str(ruta))
+
+        if ruta.exists():
+            with open(ruta, "rb") as f:
+                await mensaje.reply_document(f, filename=nombre_arch)
+
+    await responder_registrando(
+        mensaje,
+        user_id,
+        mensaje.text or getattr(mensaje.document, "file_name", ""),
+        f"Tarea {tarea.id} registrada.",
+        "tareas",
+    )

--- a/tests/test_detectar_tarea_mail.py
+++ b/tests/test_detectar_tarea_mail.py
@@ -1,0 +1,168 @@
+import sys
+import importlib
+import asyncio
+from types import ModuleType, SimpleNamespace
+from pathlib import Path
+from datetime import datetime
+from sqlalchemy.orm import sessionmaker
+import os
+import tempfile
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT_DIR / "Sandy bot"))
+
+# Stubs de telegram
+telegram_stub = ModuleType("telegram")
+
+class Message:
+    def __init__(self, text="", document=None):
+        self.text = text
+        self.document = document
+        self.sent = None
+
+    async def reply_document(self, f, filename=None):
+        self.sent = filename
+
+    async def reply_text(self, *a, **k):
+        pass
+
+
+class Document:
+    def __init__(self, file_name="mail.txt", content=""):
+        self.file_name = file_name
+        self._content = content
+
+    async def get_file(self):
+        class F:
+            async def download_to_drive(_, path):
+                Path(path).write_text(self._content)
+
+        return F()
+
+
+class Update:
+    def __init__(self, message=None, edited_message=None, callback_query=None):
+        self.message = message
+        self.edited_message = edited_message
+        self.callback_query = callback_query
+        self.effective_user = SimpleNamespace(id=1)
+
+
+telegram_stub.Update = Update
+telegram_stub.Message = Message
+telegram_stub.CallbackQuery = SimpleNamespace
+telegram_stub.Document = Document
+sys.modules.setdefault("telegram", telegram_stub)
+
+telegram_ext_stub = ModuleType("telegram.ext")
+class ContextTypes:
+    DEFAULT_TYPE = object
+
+telegram_ext_stub.ContextTypes = ContextTypes
+sys.modules.setdefault("telegram.ext", telegram_ext_stub)
+
+# Stubs de openai y jsonschema
+openai_stub = ModuleType("openai")
+class AsyncOpenAI:
+    def __init__(self, api_key=None):
+        self.chat = type("c", (), {"completions": type("comp", (), {"create": lambda *a, **k: None})()})()
+
+openai_stub.AsyncOpenAI = AsyncOpenAI
+sys.modules.setdefault("openai", openai_stub)
+
+jsonschema_stub = ModuleType("jsonschema")
+jsonschema_stub.validate = lambda *a, **k: None
+jsonschema_stub.ValidationError = type("ValidationError", (Exception,), {})
+sys.modules.setdefault("jsonschema", jsonschema_stub)
+
+# Variables de entorno necesarias
+os.environ.update({
+    "TELEGRAM_TOKEN": "x",
+    "OPENAI_API_KEY": "x",
+    "NOTION_TOKEN": "x",
+    "NOTION_DATABASE_ID": "x",
+    "DB_USER": "u",
+    "DB_PASSWORD": "p",
+    "SLACK_WEBHOOK_URL": "x",
+    "SUPERVISOR_DB_ID": "x",
+    "DB_HOST": "localhost",
+    "DB_PORT": "5432",
+    "DB_NAME": "sandy",
+})
+
+# Base de datos en memoria
+import sqlalchemy
+orig_engine = sqlalchemy.create_engine
+sqlalchemy.create_engine = lambda *a, **k: orig_engine("sqlite:///:memory:")
+import sandybot.database as bd
+sqlalchemy.create_engine = orig_engine
+bd.SessionLocal = sessionmaker(bind=bd.engine, expire_on_commit=False)
+bd.Base.metadata.create_all(bind=bd.engine)
+
+TEMP_DIR = None
+
+
+def test_detectar_tarea_mail(tmp_path, monkeypatch):
+    global TEMP_DIR
+    TEMP_DIR = tmp_path
+    orig_tmp = tempfile.gettempdir
+
+    def _tmpdir():
+        return str(TEMP_DIR)
+
+    tempfile.gettempdir = _tmpdir
+
+    pkg = "sandybot.handlers"
+    if pkg not in sys.modules:
+        handlers_pkg = ModuleType(pkg)
+        handlers_pkg.__path__ = [str(ROOT_DIR / "Sandy bot" / "sandybot" / "handlers")]
+        sys.modules[pkg] = handlers_pkg
+
+    mod_name = f"{pkg}.detectar_tarea_mail"
+    spec = importlib.util.spec_from_file_location(
+        mod_name,
+        ROOT_DIR / "Sandy bot" / "sandybot" / "handlers" / "detectar_tarea_mail.py",
+    )
+    tarea_mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = tarea_mod
+    spec.loader.exec_module(tarea_mod)
+
+    # Crear servicio previo
+    servicio = bd.crear_servicio(nombre="Srv", cliente="Cli")
+
+    # Contar registros antes de ejecutar
+    with bd.SessionLocal() as s:
+        prev_tareas = s.query(bd.TareaProgramada).count()
+        prev_rels = s.query(bd.TareaServicio).count()
+
+    # Stub GPT para devolver JSON
+    class GPTStub(tarea_mod.gpt.__class__):
+        async def consultar_gpt(self, mensaje: str, cache: bool = True) -> str:
+            return (
+                '{"inicio": "2024-01-02T08:00:00", "fin": "2024-01-02T10:00:00", '
+                '"tipo": "Mant", "afectacion": "1h", "ids": [' + str(servicio.id) + ']}'
+            )
+
+    tarea_mod.gpt = GPTStub()
+
+    msg = Message("/detectar_tarea Cliente ejemplo")
+    update = Update(message=msg)
+    ctx = SimpleNamespace(args=["Cliente", "ejemplo"])
+
+    asyncio.run(tarea_mod.detectar_tarea_mail(update, ctx))
+
+    with bd.SessionLocal() as s:
+        tareas = s.query(bd.TareaProgramada).all()
+        rels = s.query(bd.TareaServicio).all()
+
+    tempfile.gettempdir = orig_tmp
+
+    assert len(tareas) == prev_tareas + 1
+    assert len(rels) == prev_rels + 1
+    tarea = tareas[-1]
+    rel = rels[-1]
+    assert rel.tarea_id == tarea.id
+    assert rel.servicio_id == servicio.id
+    ruta = tmp_path / f"tarea_{tarea.id}.msg"
+    assert ruta.exists()
+    assert msg.sent == ruta.name


### PR DESCRIPTION
## Resumen
- crear handler `detectar_tarea_mail` para extraer datos de un correo
- exponer el nuevo handler y comando `/detectar_tarea`
- actualizar documentación
- cubrir la funcionalidad con pruebas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e201ef188330ba6b5b3eeea39736