### PR TITLE
Mejora inserción de TareaServicio

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -548,9 +548,10 @@ def crear_tarea_programada(
         session.commit()
         session.refresh(tarea)
 
-        for sid in servicios:
-            session.add(TareaServicio(tarea_id=tarea.id, servicio_id=sid))
-
+        relaciones = [
+            TareaServicio(tarea_id=tarea.id, servicio_id=sid) for sid in servicios
+        ]
+        session.bulk_save_objects(relaciones)
         session.commit()
         return tarea
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -281,3 +281,22 @@ def test_tarea_servicio_unica():
         with bd.SessionLocal() as session:
             session.add(bd.TareaServicio(tarea_id=tarea.id, servicio_id=s.id))
             session.commit()
+
+
+def test_crear_tarea_varios_servicios():
+    s1 = bd.crear_servicio(nombre="Sv1", cliente="C1")
+    s2 = bd.crear_servicio(nombre="Sv2", cliente="C2")
+    tarea = bd.crear_tarea_programada(
+        datetime(2024, 1, 3, 8),
+        datetime(2024, 1, 3, 10),
+        "Mantenimiento",
+        [s1.id, s2.id],
+    )
+    with bd.SessionLocal() as session:
+        rels = (
+            session.query(bd.TareaServicio)
+            .filter(bd.TareaServicio.tarea_id == tarea.id)
+            .all()
+        )
+    assert len(rels) == 2
+    assert {r.servicio_id for r in rels} == {s1.id, s2.id}


### PR DESCRIPTION
## Resumen
- optimiza `crear_tarea_programada` para almacenar relaciones con `bulk_save_objects`
- comprueba que cada tarea genere las filas necesarias en `tareas_servicio`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ec7f1df88330a5250bdd3a4216d1