### PR TITLE
Add txt backup when creating Outlook MSG

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -310,6 +310,11 @@ def generar_archivo_msg(
 
             mail.Body = contenido + ("\n\n" + firma if firma else "")
             mail.SaveAs(ruta, 3)  # 3 = olMSGUnicode
+            try:
+                with open(f"{ruta}.txt", "w", encoding="utf-8") as txt:
+                    txt.write(mail.Body)
+            except Exception as e:  # pragma: no cover - depende del entorno
+                logger.error("No se pudo escribir el texto: %s", e)
             return ruta
         except Exception as e:  # pragma: no cover
             logger.error("Error generando archivo MSG: %s", e)

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -280,4 +280,6 @@ def test_generar_archivo_msg_win32(tmp_path, monkeypatch):
     assert resultado == str(ruta)
     assert outlook.saved == (str(ruta), 3)
     assert ruta.exists()
-    assert "Telco2" in ruta.read_text(encoding="utf-8")
+    texto = Path(str(ruta) + ".txt")
+    assert texto.exists()
+    assert "Telco2" in texto.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- keep body text for Outlook emails in a `.txt` file
- validate txt backup in the Outlook stub test

## Testing
- `pytest tests/test_email_utils.py::test_generar_archivo_msg_win32 -q`
- `pytest tests/test_email_utils.py::test_generar_archivo_msg -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495aa1f0188330a8cdda8f976d3fff