### PR TITLE
Unificar stubs de Telegram en pruebas

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ del sistema para corregir el problema.
 ## Pruebas automatizadas
 
 Para validar el funcionamiento del proyecto se incluye una suite de pruebas basada en `pytest`.
-Es necesario contar con las bibliotecas `openpyxl`, `python-docx` y `pandas` para que todas las
-pruebas puedan ejecutarse correctamente.
+Las dependencias externas como `openpyxl`, `python-docx` y `pandas` se utilizan en algunas pruebas,
+pero no son obligatorias gracias a los stubs incluidos.
 
 Antes de ejecutar `pytest` es recomendable preparar el entorno con `setup_env.sh`.
 Este script crea el virtualenv en `.venv` y realiza la instalación de

--- a/tests/telegram_stub.py
+++ b/tests/telegram_stub.py
@@ -1,0 +1,64 @@
+from types import ModuleType, SimpleNamespace
+from pathlib import Path
+import sys
+
+class Message:
+    def __init__(self, text="", document=None, voice=None):
+        self.text = text
+        self.document = document
+        self.documento = None
+        self.voice = voice
+        self.sent = None
+        self.from_user = SimpleNamespace(id=1)
+
+    async def reply_document(self, f, filename=None):
+        self.sent = filename
+        self.documento = filename
+
+    async def reply_text(self, *a, **k):
+        pass
+
+class CallbackQuery:
+    def __init__(self, message=None):
+        self.message = message
+
+class Document:
+    def __init__(self, file_name="file.txt", content=""):
+        self.file_name = file_name
+        self._content = content
+
+    async def get_file(self):
+        class F:
+            async def download_to_drive(_, path):
+                Path(path).write_text(self._content)
+        return F()
+
+class Update:
+    def __init__(self, message=None, edited_message=None, callback_query=None):
+        self.message = message
+        self.edited_message = edited_message
+        self.callback_query = callback_query
+        self.effective_user = getattr(message, "from_user", SimpleNamespace(id=1))
+
+class InlineKeyboardButton:
+    def __init__(self, *a, **k):
+        pass
+
+class InlineKeyboardMarkup:
+    def __init__(self, *a, **k):
+        pass
+
+telegram_mod = ModuleType("telegram")
+telegram_mod.Update = Update
+telegram_mod.Message = Message
+telegram_mod.CallbackQuery = CallbackQuery
+telegram_mod.InlineKeyboardButton = InlineKeyboardButton
+telegram_mod.InlineKeyboardMarkup = InlineKeyboardMarkup
+telegram_mod.Document = Document
+sys.modules.setdefault("telegram", telegram_mod)
+
+telegram_ext = ModuleType("telegram.ext")
+class ContextTypes:
+    DEFAULT_TYPE = object
+telegram_ext.ContextTypes = ContextTypes
+sys.modules.setdefault("telegram.ext", telegram_ext)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -14,22 +14,7 @@ from sqlalchemy.orm import sessionmaker
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
-# Crear stub del módulo telegram para las utilidades
-telegram_stub = importlib.util.module_from_spec(importlib.machinery.ModuleSpec("telegram", None))
-class Message:
-    def __init__(self, text=""):
-        self.text = text
-class CallbackQuery:
-    def __init__(self, message=None):
-        self.message = message
-class Update:
-    def __init__(self, message=None, edited_message=None, callback_query=None):
-        self.message = message
-        self.edited_message = edited_message
-        self.callback_query = callback_query
-telegram_stub.Update = Update
-telegram_stub.Message = Message
-sys.modules.setdefault("telegram", telegram_stub)
+import tests.telegram_stub  # Registra las clases fake de telegram
 
 # Stub de dotenv requerido por config
 dotenv_stub = importlib.util.module_from_spec(importlib.machinery.ModuleSpec("dotenv", None))

--- a/tests/test_detectar_tarea_mail.py
+++ b/tests/test_detectar_tarea_mail.py
@@ -11,55 +11,7 @@ import tempfile
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
-# Stubs de telegram
-telegram_stub = ModuleType("telegram")
-
-class Message:
-    def __init__(self, text="", document=None):
-        self.text = text
-        self.document = document
-        self.sent = None
-
-    async def reply_document(self, f, filename=None):
-        self.sent = filename
-
-    async def reply_text(self, *a, **k):
-        pass
-
-
-class Document:
-    def __init__(self, file_name="mail.txt", content=""):
-        self.file_name = file_name
-        self._content = content
-
-    async def get_file(self):
-        class F:
-            async def download_to_drive(_, path):
-                Path(path).write_text(self._content)
-
-        return F()
-
-
-class Update:
-    def __init__(self, message=None, edited_message=None, callback_query=None):
-        self.message = message
-        self.edited_message = edited_message
-        self.callback_query = callback_query
-        self.effective_user = SimpleNamespace(id=1)
-
-
-telegram_stub.Update = Update
-telegram_stub.Message = Message
-telegram_stub.CallbackQuery = SimpleNamespace
-telegram_stub.Document = Document
-sys.modules.setdefault("telegram", telegram_stub)
-
-telegram_ext_stub = ModuleType("telegram.ext")
-class ContextTypes:
-    DEFAULT_TYPE = object
-
-telegram_ext_stub.ContextTypes = ContextTypes
-sys.modules.setdefault("telegram.ext", telegram_ext_stub)
+from tests.telegram_stub import Message, Update  # Registra las clases fake de telegram
 
 # Stubs de openai y jsonschema
 openai_stub = ModuleType("openai")

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,29 +1,13 @@
 import sys
 import os
 import importlib
+import tests.telegram_stub  # Registra las clases fake de telegram
 from types import ModuleType
 from pathlib import Path
 from sqlalchemy.orm import sessionmaker
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT_DIR / "Sandy bot"))
-
-# Stub de telegram requerido por utils
-telegram_stub = ModuleType("telegram")
-class Message:
-    def __init__(self, text=""):
-        self.text = text
-class CallbackQuery:
-    def __init__(self, message=None):
-        self.message = message
-class Update:
-    def __init__(self, message=None, edited_message=None, callback_query=None):
-        self.message = message
-        self.edited_message = edited_message
-        self.callback_query = callback_query
-telegram_stub.Update = Update
-telegram_stub.Message = Message
-sys.modules.setdefault("telegram", telegram_stub)
 
 # Stub de dotenv
 dotenv_stub = ModuleType("dotenv")

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -9,6 +9,7 @@ from datetime import datetime
 # Preparar rutas
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT_DIR / "Sandy bot"))
+import tests.telegram_stub  # Registra las clases fake de telegram
 
 # Stub de dotenv para Config
 dotenv_stub = types.ModuleType("dotenv")
@@ -225,6 +226,7 @@ def test_generar_archivo_msg_win32(tmp_path, monkeypatch):
     class OutlookStub:
         def __init__(self):
             self.saved = None
+            self.Body = ""
 
         def Dispatch(self, name):
             return self
@@ -234,7 +236,7 @@ def test_generar_archivo_msg_win32(tmp_path, monkeypatch):
 
         def SaveAs(self, path, fmt):
             self.saved = (path, fmt)
-            Path(path).touch()
+            Path(path).write_text(self.Body or "")
 
     class PycomStub:
         def __init__(self):

--- a/tests/test_tarea_programada.py
+++ b/tests/test_tarea_programada.py
@@ -12,43 +12,7 @@ import tempfile
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
-# Stub de telegram similar al usado en otros tests
-telegram_stub = ModuleType("telegram")
-class Message:
-    def __init__(self, text=""):
-        self.text = text
-        self.documento = None
-    async def reply_document(self, f, filename=None):
-        self.documento = filename
-    async def reply_text(self, *a, **k):
-        pass
-class CallbackQuery:
-    def __init__(self, message=None):
-        self.message = message
-class Update:
-    def __init__(self, message=None, edited_message=None, callback_query=None):
-        self.message = message
-        self.edited_message = edited_message
-        self.callback_query = callback_query
-        self.effective_user = SimpleNamespace(id=1)
-class InlineKeyboardButton:
-    def __init__(self, *a, **k):
-        pass
-class InlineKeyboardMarkup:
-    def __init__(self, *a, **k):
-        pass
-telegram_stub.Update = Update
-telegram_stub.Message = Message
-telegram_stub.CallbackQuery = CallbackQuery
-telegram_stub.InlineKeyboardButton = InlineKeyboardButton
-telegram_stub.InlineKeyboardMarkup = InlineKeyboardMarkup
-telegram_ext_stub = ModuleType("telegram.ext")
-class ContextTypes:
-    DEFAULT_TYPE = object
-telegram_ext_stub.ContextTypes = ContextTypes
-telegram_stub.ext = telegram_ext_stub
-sys.modules.setdefault("telegram", telegram_stub)
-sys.modules.setdefault("telegram.ext", telegram_ext_stub)
+from tests.telegram_stub import Message, Update  # Registra las clases fake de telegram
 
 # Stubs de openai y jsonschema para importar gpt_handler sin dependencias
 openai_stub = ModuleType("openai")


### PR DESCRIPTION
## Summary
- añadir modulo `telegram_stub` con clases Update, Message, etc.
- usar este stub en las pruebas que inicializan la base
- mejorar stub de Outlook en `test_email_utils`
- aclarar en la documentación que las bibliotecas externas son opcionales

## Testing
- `./setup_env.sh`
- `source .venv/bin/activate && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495abf07d08330a410237718cff325