### PR TITLE
Elimina archivo txt temporal tras generar mensajes

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -310,12 +310,19 @@ def generar_archivo_msg(
 
             mail.Body = contenido + ("\n\n" + firma if firma else "")
             mail.SaveAs(ruta, 3)  # 3 = olMSGUnicode
-  # Guardamos además una copia de texto plano para facilitar pruebas unitarias
+            # Copia temporal de texto para algunas pruebas
+            temp_txt = f"{ruta}.txt"
             try:
-                with open(f"{ruta}.txt", "w", encoding="utf-8") as txt:
+                with open(temp_txt, "w", encoding="utf-8") as txt:
                     txt.write(mail.Body)
             except Exception as e:  # pragma: no cover - depende del entorno
                 logger.error("No se pudo escribir el texto: %s", e)
+            finally:
+                # Eliminar el archivo auxiliar para no dejar residuos
+                try:
+                    os.remove(temp_txt)
+                except OSError:
+                    pass
             return ruta
         except Exception as e:  # pragma: no cover
             logger.error("Error generando archivo MSG: %s", e)

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -282,6 +282,5 @@ def test_generar_archivo_msg_win32(tmp_path, monkeypatch):
     assert resultado == str(ruta)
     assert outlook.saved == (str(ruta), 3)
     assert ruta.exists()
-    texto = Path(str(ruta) + ".txt")
-    assert texto.exists()
-    assert "Telco2" in texto.read_text(encoding="utf-8")
+    assert "Telco2" in ruta.read_text(encoding="utf-8")
+    assert not Path(str(ruta) + ".txt").exists()


### PR DESCRIPTION
## Summary
- borrado del archivo `ruta.txt` luego de exportar el `.msg`
- pruebas actualizadas verifican que el `.txt` ya no existe

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849623ecf188330bd603a3a5250cdbc