### PR TITLE
Añade dependencia extract-msg y manejo de importación

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Este repositorio contiene el proyecto SandyBot. Para ejecutarlo se requiere
 instalar las dependencias listadas en `Sandy bot/requirements.txt`. Se recomienda usar
 la versión `openai>=1.0.0` para garantizar compatibilidad con la nueva
-API utilizada en `sandybot`.
+API utilizada en `sandybot`. También se necesita `extract-msg` para leer los
+archivos `.msg` con el comando `/procesar_correos`.
 Desde esta versión el bot también acepta mensajes de voz, los descarga y
 transcribe automáticamente utilizando la API de OpenAI.
 
@@ -141,7 +142,8 @@ formatear el mensaje.
 
 Usá `/procesar_correos` para analizar los avisos `.MSG` que reciba el
 bot y crear automáticamente cada tarea programada. De esta manera se
-evita cargar la información de forma manual.
+evita cargar la información de forma manual. Este comando necesita la
+biblioteca `extract-msg` para leer los mensajes.
 Por ejemplo:
 ```bash
 /procesar_correos Cliente

--- a/Sandy bot/requirements.txt
+++ b/Sandy bot/requirements.txt
@@ -8,6 +8,7 @@ python-docx>=0.8.0
 notion-client>=1.0.0
 fuzzywuzzy>=0.18.0
 python-Levenshtein>=0.12.0
+extract-msg==0.23.1
 pywin32>=300; sys_platform == 'win32'
 jsonschema>=4.0.0
 SQLAlchemy>=1.4

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -9,7 +9,13 @@ from pathlib import Path
 from telegram import Update
 from telegram.ext import ContextTypes
 
-import extract_msg
+try:
+    import extract_msg
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "No se encontró la librería 'extract-msg'. Instalala para usar "/
+        "procesar_correos'."
+    ) from exc
 
 from ..utils import obtener_mensaje
 from ..gpt_handler import gpt


### PR DESCRIPTION
## Resumen
- agrega `extract-msg` en el archivo de dependencias
- captura un error claro al importar la librería en `procesar_correos.py`
- documenta en el README la necesidad de `extract-msg` para `/procesar_correos`

## Testing
- `bash setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496bad321c8330b9d2c2307f06c22f