### PR TITLE
Implementar notificación por correo y filtro por carrier

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,14 @@ tarea = crear_tarea_programada(
 
 Con `/listar_tareas` podés consultar las ventanas ya registradas.
 Los parámetros `cliente`, `servicio` e intervalo de fechas son opcionales
-y se pueden combinar libremente.
+y se pueden combinar libremente. También se acepta `carrier=<nombre>`
+para filtrar por carrier.
 Ejemplos:
 
 ```bash
 /listar_tareas ClienteA
 /listar_tareas 7 2024-01-01 2024-01-05
+/listar_tareas carrier=Telecom
 ```
 El bot muestra inicio, fin, tipo y los servicios afectados.
 
@@ -136,12 +138,14 @@ principales. Este aviso puede abrirse con Outlook y reenviarse o
 ajustarse antes de enviarlo. Si `pywin32` está presente, el sistema
 aplica la firma ubicada en `SIGNATURE_PATH` y aprovecha Outlook para
 formatear el mensaje.
+Además Sandy envía el aviso por correo a los destinatarios configurados para el cliente.
 
 ### Procesar correos y registrar tareas
 
 Usá `/procesar_correos` para analizar los avisos `.MSG` que reciba el
 bot y crear automáticamente cada tarea programada. De esta manera se
-evita cargar la información de forma manual.
+evita cargar la información de forma manual. El aviso generado se envía
+automáticamente por correo a los contactos del cliente.
 Por ejemplo:
 ```bash
 /procesar_correos Cliente

--- a/Sandy bot/sandybot/handlers/listar_tareas.py
+++ b/Sandy bot/sandybot/handlers/listar_tareas.py
@@ -8,6 +8,7 @@ from ..database import (
     TareaProgramada,
     TareaServicio,
     Servicio,
+    Carrier,
     SessionLocal,
 )
 
@@ -24,6 +25,7 @@ async def listar_tareas(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     servicio_id = None
     fecha_inicio = None
     fecha_fin = None
+    carrier_nombre = None
 
     for arg in context.args:
         if arg.isdigit():
@@ -37,7 +39,9 @@ async def listar_tareas(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
                 fecha_fin = fecha
             continue
         except ValueError:
-            if not cliente:
+            if arg.startswith("carrier="):
+                carrier_nombre = arg.split("=", 1)[1]
+            elif not cliente:
                 cliente = arg
 
     with SessionLocal() as session:
@@ -50,6 +54,9 @@ async def listar_tareas(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             consulta = consulta.filter(TareaProgramada.fecha_inicio >= fecha_inicio)
         if fecha_fin:
             consulta = consulta.filter(TareaProgramada.fecha_fin <= fecha_fin)
+        if carrier_nombre:
+            consulta = consulta.join(Carrier, TareaProgramada.carrier_id == Carrier.id)
+            consulta = consulta.filter(Carrier.nombre == carrier_nombre)
         consulta = consulta.order_by(TareaProgramada.fecha_inicio)
         tareas = consulta.all()
 

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -21,7 +21,7 @@ from ..database import (
     Carrier,
     SessionLocal,
 )
-from ..email_utils import generar_archivo_msg
+from ..email_utils import generar_archivo_msg, enviar_correo
 from ..registrador import responder_registrando
 
 logger = logging.getLogger(__name__)
@@ -143,6 +143,18 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             nombre_arch = f"tarea_{tarea.id}.msg"
             ruta_msg = Path(tempfile.gettempdir()) / nombre_arch
             generar_archivo_msg(tarea, cliente, [s for s in servicios if s], str(ruta_msg))
+
+            cuerpo = ""
+            try:
+                cuerpo = Path(ruta_msg).read_text(encoding="utf-8", errors="ignore")
+            except Exception:
+                pass
+            enviar_correo(
+                f"Aviso de tarea programada - {cliente.nombre}",
+                cuerpo,
+                cliente.id,
+            )
+
             if ruta_msg.exists():
                 with open(ruta_msg, "rb") as f:
                     await mensaje.reply_document(f, filename=nombre_arch)

--- a/Sandy bot/sandybot/handlers/tarea_programada.py
+++ b/Sandy bot/sandybot/handlers/tarea_programada.py
@@ -14,7 +14,7 @@ from ..database import (
     Carrier,
     SessionLocal,
 )
-from ..email_utils import generar_archivo_msg
+from ..email_utils import generar_archivo_msg, enviar_correo
 
 
 async def registrar_tarea_programada(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -90,6 +90,17 @@ async def registrar_tarea_programada(update: Update, context: ContextTypes.DEFAU
         nombre_arch = f"tarea_{tarea.id}.msg"
         ruta = Path(tempfile.gettempdir()) / nombre_arch
         generar_archivo_msg(tarea, cliente, [s for s in servicios if s], str(ruta))
+
+        cuerpo = ""
+        try:
+            cuerpo = Path(ruta).read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            pass
+        enviar_correo(
+            f"Aviso de tarea programada - {cliente.nombre}",
+            cuerpo,
+            cliente.id,
+        )
 
         if ruta.exists():
             with open(ruta, "rb") as f:

--- a/tests/test_listar_tareas.py
+++ b/tests/test_listar_tareas.py
@@ -111,3 +111,33 @@ def test_listar_tareas_filtro_fechas():
     texto = asyncio.run(_ejecutar(["2024-02-01", "2024-02-02"]))
     assert "OK" in texto
     assert "Late" not in texto
+
+
+def test_listar_tareas_filtro_carrier():
+    car1 = bd.Carrier(nombre="C1")
+    car2 = bd.Carrier(nombre="C2")
+    with bd.SessionLocal() as s:
+        s.add_all([car1, car2])
+        s.commit()
+        s.refresh(car1)
+        s.refresh(car2)
+
+    srv = bd.crear_servicio(nombre="S5", cliente="E")
+    bd.crear_tarea_programada(
+        datetime(2024, 4, 1, 8),
+        datetime(2024, 4, 1, 10),
+        "A",
+        [srv.id],
+        carrier_id=car1.id,
+    )
+    bd.crear_tarea_programada(
+        datetime(2024, 4, 2, 8),
+        datetime(2024, 4, 2, 10),
+        "B",
+        [srv.id],
+        carrier_id=car2.id,
+    )
+
+    texto = asyncio.run(_ejecutar([f"carrier={car1.nombre}"]))
+    assert "A" in texto
+    assert "B" not in texto

--- a/tests/test_procesar_correos.py
+++ b/tests/test_procesar_correos.py
@@ -124,6 +124,14 @@ def test_procesar_correos(tmp_path):
     sys.modules[mod_name] = tarea_mod
     spec.loader.exec_module(tarea_mod)
 
+    enviados = {}
+    def fake_enviar(asunto, cuerpo, cid, **k):
+        enviados["cid"] = cid
+        enviados["asunto"] = asunto
+        enviados["cuerpo"] = cuerpo
+        return True
+    tarea_mod.enviar_correo = fake_enviar
+
     servicio = bd.crear_servicio(nombre="Srv", cliente="Cli")
 
     class GPTStub(tarea_mod.gpt.__class__):
@@ -149,6 +157,7 @@ def test_procesar_correos(tmp_path):
     with bd.SessionLocal() as s:
         tareas = s.query(bd.TareaProgramada).all()
         rels = s.query(bd.TareaServicio).all()
+        cli = s.query(bd.Cliente).filter_by(nombre="Cliente").first()
 
     tempfile.gettempdir = orig_tmp
 
@@ -161,3 +170,5 @@ def test_procesar_correos(tmp_path):
     ruta = tmp_path / f"tarea_{tarea.id}.msg"
     assert ruta.exists()
     assert msg.sent == ruta.name
+    assert enviados["cid"] == cli.id
+    assert "Mant" in enviados["cuerpo"]


### PR DESCRIPTION
## Summary
- enviar correo automático al registrar tarea programada
- enviar correo automático al procesar correos
- permitir filtro `carrier` en `listar_tareas`
- documentar la notificación y el nuevo filtro
- agregar pruebas para el envío y el filtrado

## Testing
- `pip install sqlalchemy openpyxl python-docx --quiet`
- `pip install pandas --quiet`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68496baf0250833086bacccad7c66f82