### PR TITLE
Eliminar segunda consulta en listar_tareas

### DIFF
--- a/Sandy bot/sandybot/handlers/listar_tareas.py
+++ b/Sandy bot/sandybot/handlers/listar_tareas.py
@@ -85,17 +85,6 @@ async def listar_tareas(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             .all()
         )
 
-        filas = (
-            consulta.group_by(
-                TareaProgramada.id,
-                TareaProgramada.fecha_inicio,
-                TareaProgramada.fecha_fin,
-                TareaProgramada.tipo_tarea,
-            )
-            .order_by(TareaProgramada.fecha_inicio)
-            .all()
-        )
-
         if not filas:
             texto = "No se encontraron tareas."
         else:


### PR DESCRIPTION
## Summary
- quita un bloque `group_by`/`order_by` duplicado en `listar_tareas`

## Testing
- `pytest -q tests/test_listar_tareas.py`

------
https://chatgpt.com/codex/tasks/task_e_684974bf948c8330bedc2763af3115fb