### PR TITLE
Arreglo ortográfico en instrucción sobre correos

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,7 @@ Además Sandy envía el aviso por correo a los destinatarios configurados para e
 
 ### Procesar correos y registrar tareas
 
-Usá `/procesar_correos` para analizar los avisos `.MSG` que reciba el
-
-evita cargar la información de forma manual. El aviso generado se envía
-automáticamente por correo a los contactos del cliente.
+Usá `/procesar_correos` para analizar los avisos `.MSG` que reciba el bot y evitar cargar la información de forma manual. El aviso generado se envía automáticamente por correo a los contactos del cliente.
 
 Por ejemplo:
 ```bash


### PR DESCRIPTION
## Summary
- corregir el párrafo que explica `/procesar_correos`

## Testing
- `setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684974c7627c83309369e8e9f235d0f3