### PR TITLE
Remove unused imports in email_utils

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -23,8 +23,6 @@ SIGNATURE_PATH = (
 )
 from .database import SessionLocal, Cliente, Servicio, TareaProgramada, Carrier
 from .utils import (
-    cargar_destinatarios as utils_cargar_dest,
-    guardar_destinatarios as utils_guardar,
     cargar_json,
     guardar_json,
 )


### PR DESCRIPTION
## Summary
- limpiar `email_utils` quitando importaciones que no se usan

## Testing
- `source .venv/bin/activate && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497847c9508330b9268fc6fcb5ba16