### PR TITLE
Centralizar creación de tareas desde correos

### DIFF
--- a/tests/test_detectar_tarea_mail.py
+++ b/tests/test_detectar_tarea_mail.py
@@ -88,14 +88,15 @@ def test_detectar_tarea_mail(tmp_path, monkeypatch):
         prev_rels = s.query(bd.TareaServicio).count()
 
     # Stub GPT para devolver JSON
-    class GPTStub(tarea_mod.gpt.__class__):
+    email_mod = importlib.import_module("sandybot.email_utils")
+    class GPTStub(email_mod.gpt.__class__):
         async def consultar_gpt(self, mensaje: str, cache: bool = True) -> str:
             return (
                 '{"inicio": "2024-01-02T08:00:00", "fin": "2024-01-02T10:00:00", '
                 '"tipo": "Mant", "afectacion": "1h", "ids": [' + str(servicio.id) + ']}'
             )
 
-    tarea_mod.gpt = GPTStub()
+    email_mod.gpt = GPTStub()
 
     msg = Message("/detectar_tarea Cliente ejemplo")
     update = Update(message=msg)

--- a/tests/test_procesar_correos.py
+++ b/tests/test_procesar_correos.py
@@ -135,14 +135,15 @@ def test_procesar_correos(tmp_path):
 
     servicio = bd.crear_servicio(nombre="Srv", cliente="Cli")
 
-    class GPTStub(tarea_mod.gpt.__class__):
+    email_mod = importlib.import_module("sandybot.email_utils")
+    class GPTStub(email_mod.gpt.__class__):
         async def consultar_gpt(self, mensaje: str, cache: bool = True) -> str:
             return (
                 '{"inicio": "2024-01-02T08:00:00", "fin": "2024-01-02T10:00:00", '
                 '"tipo": "Mant", "afectacion": "1h", "ids": [' + str(servicio.id) + ']}'
             )
 
-    tarea_mod.gpt = GPTStub()
+    email_mod.gpt = GPTStub()
 
     doc = Document(content="dummy")
     msg = Message(document=doc)
@@ -209,14 +210,15 @@ def test_procesar_correos_varios(tmp_path):
 
     servicio = bd.crear_servicio(nombre="Srv", cliente="Cli")
 
-    class GPTStub(tarea_mod.gpt.__class__):
+    email_mod = importlib.import_module("sandybot.email_utils")
+    class GPTStub(email_mod.gpt.__class__):
         async def consultar_gpt(self, mensaje: str, cache: bool = True) -> str:
             return (
                 '{"inicio": "2024-01-02T08:00:00", "fin": "2024-01-02T10:00:00", '
                 '"tipo": "Mant", "afectacion": "1h", "ids": [' + str(servicio.id) + ']}'
             )
 
-    tarea_mod.gpt = GPTStub()
+    email_mod.gpt = GPTStub()
 
     doc1 = Document(file_name="uno.msg", content="dummy")
     doc2 = Document(file_name="dos.msg", content="dummy")


### PR DESCRIPTION
## Summary
- crear función `procesar_correo_a_tarea` para extraer info y registrar tareas
- usar la nueva función en `detectar_tarea_mail` y `procesar_correos`
- ajustar pruebas para emplear un único punto de entrada

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_68497849ebd483309587ae0ff3b33987