### PR TITLE
Añade restricción única en tareas_servicio

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -173,9 +173,12 @@ class TareaServicio(Base):
     tarea_id = Column(Integer, ForeignKey("tareas_programadas.id"), index=True)
     servicio_id = Column(Integer, ForeignKey("servicios.id"), index=True)
 
+    # Evita filas duplicadas con la misma tarea y servicio
     __table_args__ = (
         UniqueConstraint(
-            "tarea_id", "servicio_id", name="uix_tarea_servicio"
+            "tarea_id",
+            "servicio_id",
+            name="uix_tarea_servicio",
         ),
     )
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -309,3 +309,16 @@ def test_crear_tarea_varios_servicios():
         )
     assert len(rels) == 2
     assert {r.servicio_id for r in rels} == {s1.id, s2.id}
+
+
+def test_crear_tarea_servicio_repetido():
+    """Crear una tarea con el mismo servicio dos veces provoca un error."""
+    s = bd.crear_servicio(nombre="SvRep", cliente="CliR")
+
+    with pytest.raises(sqlalchemy.exc.IntegrityError):
+        bd.crear_tarea_programada(
+            datetime(2024, 1, 4, 8),
+            datetime(2024, 1, 4, 10),
+            "Mantenimiento",
+            [s.id, s.id],
+        )


### PR DESCRIPTION
## Resumen
- se documenta la restricción `UniqueConstraint` para evitar duplicados en `TareaServicio`
- se incorpora prueba que confirma el error al intentar registrar la misma relación dos veces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684987d43c9083308c630805641be90d