### PR TITLE
Actualizar referencias de correo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,9 +162,9 @@ Salida esperada:
 
 ## 📧 Envío de correos
 
-El bot puede enviar listados por email usando los destinatarios guardados en `Sandy bot/data/destinatarios.json`. Configurá `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER` y `SMTP_PASSWORD` junto a `EMAIL_FROM` en el `.env`. Las variables `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_USER` y `EMAIL_PASSWORD` siguen siendo válidas para compatibilidad.
+El bot envía listados por email a los contactos guardados en la tabla `clientes`. Los correos se registran con `/agregar_destinatario` y se consultan con `/listar_destinatarios`. Configurá `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER` y `SMTP_PASSWORD` junto a `EMAIL_FROM` en el `.env`. Las variables `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_USER` y `EMAIL_PASSWORD` siguen siendo válidas para compatibilidad.
 Definí también `SIGNATURE_PATH` para indicar la firma que se agrega a los mensajes generados.
 
-Al registrar tareas se crea un aviso en formato `.MSG`. Si tenés Outlook y la dependencia opcional `pywin32`, la firma se inserta de forma automática y podés editar el mensaje antes de enviarlo.
-El comando `/procesar_correos` analiza esos archivos `.MSG` y genera las tareas en la base sin intervención manual.
+Al registrar tareas se genera un aviso en formato `.MSG` y se envía de forma automática a los destinatarios correspondientes. Si tenés Outlook y la dependencia opcional `pywin32`, la firma se inserta y podés ajustar el mensaje antes de enviarlo.
+El comando `/procesar_correos` analiza esos `.MSG` y registra las tareas en la base sin intervención manual.
 


### PR DESCRIPTION
## Summary
- actualizar documentación sobre envíos de correos

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68498fa2b8388330a8932fc7c5fa6490