### PR TITLE
Fix cierre de MSG y modelo

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -176,8 +176,6 @@ class TareaServicio(Base):
 
     # Evita filas duplicadas con la misma tarea y servicio
     __table_args__ = (
-    # Evita filas duplicadas con la misma tarea y servicio
-    __table_args__ = (
         UniqueConstraint("tarea_id", "servicio_id", name="uix_tarea_servicio"),
     )
 

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -39,6 +39,8 @@ def _leer_msg(ruta: str) -> str:
         msg = extract_msg.Message(ruta)
         asunto = msg.subject or ""
         cuerpo = msg.body or ""
+        if hasattr(msg, "close"):
+            msg.close()
         return f"{asunto}\n{cuerpo}".strip()
     except Exception as exc:  # pragma: no cover - depende del archivo
         logger.error("Error leyendo MSG %s: %s", ruta, exc)


### PR DESCRIPTION
## Notas
- Se añadió el cierre del archivo `.msg` luego de leer asunto y cuerpo.
- Se corrigió la definición de `TareaServicio.__table_args__` que causaba un error de sintaxis.

## Testing
- `pytest -q tests/test_procesar_correos.py`


------
https://chatgpt.com/codex/tasks/task_e_68498fa3c0ec833088a2d2dfcf3c4500