### PR TITLE
Añadir comando para eliminar carriers

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ devuelve el archivo actualizado con los datos completados.
 
 ## Administración de carriers y destinatarios
 
-Podés crear carriers manualmente con `/agregar_carrier <nombre>` y consultarlos
-usando `/listar_carriers`.
+Podés crear carriers manualmente con `/agregar_carrier <nombre>`, consultarlos
+mediante `/listar_carriers` y borrarlos con `/eliminar_carrier <nombre>`.
 Los contactos de cada cliente se gestionan con:
 
 ```

--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -34,6 +34,7 @@ from .handlers import (
     listar_destinatarios,
     listar_carriers,
     agregar_carrier,
+    eliminar_carrier,
     registrar_tarea_programada,
     listar_tareas,
     detectar_tarea_mail,
@@ -76,6 +77,7 @@ class SandyBot:
         )
         self.app.add_handler(CommandHandler("listar_carriers", listar_carriers))
         self.app.add_handler(CommandHandler("agregar_carrier", agregar_carrier))
+        self.app.add_handler(CommandHandler("eliminar_carrier", eliminar_carrier))
         self.app.add_handler(CommandHandler("listar_tareas", listar_tareas))
         self.app.add_handler(CommandHandler("detectar_tarea", detectar_tarea_mail))
         self.app.add_handler(CommandHandler("procesar_correos", procesar_correos))

--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -176,8 +176,6 @@ class TareaServicio(Base):
 
     # Evita filas duplicadas con la misma tarea y servicio
     __table_args__ = (
-    # Evita filas duplicadas con la misma tarea y servicio
-    __table_args__ = (
         UniqueConstraint("tarea_id", "servicio_id", name="uix_tarea_servicio"),
     )
 

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -25,7 +25,7 @@ from .destinatarios import (
     eliminar_destinatario,
     listar_destinatarios,
 )
-from .carriers import listar_carriers, agregar_carrier
+from .carriers import listar_carriers, agregar_carrier, eliminar_carrier
 from .tarea_programada import registrar_tarea_programada
 from .detectar_tarea_mail import detectar_tarea_mail
 from .procesar_correos import procesar_correos
@@ -61,6 +61,7 @@ __all__ = [
     "eliminar_destinatario",
     "listar_destinatarios",
     "agregar_carrier",
+    "eliminar_carrier",
     "listar_carriers",
     "registrar_tarea_programada",
     "listar_tareas",

--- a/Sandy bot/sandybot/handlers/carriers.py
+++ b/Sandy bot/sandybot/handlers/carriers.py
@@ -61,3 +61,36 @@ async def agregar_carrier(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         texto,
         "carriers",
     )
+
+
+async def eliminar_carrier(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Elimina un carrier dado su nombre."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        return
+    user_id = update.effective_user.id
+    if not context.args:
+        await responder_registrando(
+            mensaje,
+            user_id,
+            mensaje.text or "eliminar_carrier",
+            "Usá: /eliminar_carrier <nombre>",
+            "carriers",
+        )
+        return
+    nombre = context.args[0]
+    with SessionLocal() as session:
+        carrier = session.query(Carrier).filter(Carrier.nombre == nombre).first()
+        if not carrier:
+            texto = f"{nombre} no existe."
+        else:
+            session.delete(carrier)
+            session.commit()
+            texto = f"Carrier {nombre} eliminado."
+    await responder_registrando(
+        mensaje,
+        user_id,
+        mensaje.text,
+        texto,
+        "carriers",
+    )

--- a/tests/test_carriers.py
+++ b/tests/test_carriers.py
@@ -1,0 +1,87 @@
+import sys
+import importlib
+import asyncio
+from types import ModuleType, SimpleNamespace
+from pathlib import Path
+from sqlalchemy.orm import sessionmaker
+import os
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT_DIR / "Sandy bot"))
+
+from tests.telegram_stub import Message, Update
+
+# Stub de dotenv para Config
+dotenv_stub = ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+# Variables de entorno mínimas
+os.environ.update({
+    "TELEGRAM_TOKEN": "x",
+    "OPENAI_API_KEY": "x",
+    "NOTION_TOKEN": "x",
+    "NOTION_DATABASE_ID": "x",
+    "DB_USER": "u",
+    "DB_PASSWORD": "p",
+    "SLACK_WEBHOOK_URL": "x",
+    "SUPERVISOR_DB_ID": "x",
+    "DB_HOST": "localhost",
+    "DB_PORT": "5432",
+    "DB_NAME": "sandy",
+})
+
+import sqlalchemy
+orig_engine = sqlalchemy.create_engine
+sqlalchemy.create_engine = lambda *a, **k: orig_engine("sqlite:///:memory:")
+import sandybot.database as bd
+sqlalchemy.create_engine = orig_engine
+bd.SessionLocal = sessionmaker(bind=bd.engine, expire_on_commit=False)
+bd.Base.metadata.create_all(bind=bd.engine)
+
+# Captura del texto enviado por responder_registrando
+captura = {}
+registrador_stub = ModuleType("sandybot.registrador")
+async def responder_registrando(*a, **k):
+    captura["texto"] = a[3]
+registrador_stub.responder_registrando = responder_registrando
+registrador_stub.registrar_conversacion = lambda *a, **k: None
+sys.modules["sandybot.registrador"] = registrador_stub
+
+
+def _importar():
+    pkg = "sandybot.handlers"
+    if pkg not in sys.modules:
+        handlers_pkg = ModuleType(pkg)
+        handlers_pkg.__path__ = [str(ROOT_DIR / "Sandy bot" / "sandybot" / "handlers")]
+        sys.modules[pkg] = handlers_pkg
+    mod_name = f"{pkg}.carriers"
+    sys.modules["sandybot.registrador"] = registrador_stub
+    spec = importlib.util.spec_from_file_location(mod_name, ROOT_DIR / "Sandy bot" / "sandybot" / "handlers" / "carriers.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+async def _run(func, args):
+    mod = _importar()
+    msg = Message(f"/{func}")
+    update = Update(message=msg)
+    ctx = SimpleNamespace(args=args)
+    captura.clear()
+    await getattr(mod, func)(update, ctx)
+    return captura.get("texto", "")
+
+
+def test_operaciones_carriers():
+    texto = asyncio.run(_run("agregar_carrier", ["CarrierX"]))
+    assert "agregado" in texto
+
+    texto = asyncio.run(_run("listar_carriers", []))
+    assert "CarrierX" in texto
+
+    texto = asyncio.run(_run("eliminar_carrier", ["CarrierX"]))
+    assert "eliminado" in texto
+
+    texto = asyncio.run(_run("listar_carriers", []))
+    assert "No hay carriers" in texto


### PR DESCRIPTION
## Summary
- implementar `eliminar_carrier` en los handlers de carriers
- exponer la nueva función en `__init__`
- registrar el comando en `bot.py`
- documentar en el README cómo borrar carriers
- corregir definición de `TareaServicio`
- añadir pruebas de creación, listado y eliminación de carriers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68498fa3c0d083309ff5880b0de138c5