### PR TITLE
Corrige mensaje de error al faltar extract-msg

### DIFF
--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -13,8 +13,7 @@ try:
     import extract_msg
 except ModuleNotFoundError as exc:
     raise ModuleNotFoundError(
-        "No se encontró la librería 'extract-msg'. Instalala para usar "
-        / "procesar_correos'."
+        "No se encontró la librería 'extract-msg'. Instalala para usar 'procesar_correos'."
     ) from exc
 
 from ..utils import obtener_mensaje


### PR DESCRIPTION
## Notas
- Se instala el entorno virtual y se ejecutan todas las pruebas

## Resumen
- Se reemplaza la concatenación con `/` en `procesar_correos.py` por una única cadena para evitar `TypeError` al importar cuando falta `extract-msg`

## Testing
- `./setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684999b53cdc8330af1940a8314cef31