### PR TITLE
Agregar reenviar_aviso

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ aplica la firma ubicada en `SIGNATURE_PATH` y aprovecha Outlook para
 formatear el mensaje.
 Además Sandy envía el aviso por correo a los destinatarios configurados para el cliente o para el par (cliente, carrier) cuando corresponde.
 
+### Reenviar un aviso de tarea
+
+Si necesitás volver a compartir una ventana ya registrada, ejecutá:
+
+```bash
+/reenviar_aviso <id_tarea> [carrier]
+```
+
+El bot reconstruirá el mensaje y lo enviará a los contactos del cliente.
+Además adjuntará el archivo `.MSG` en el chat para facilitar el reenvío manual.
+
+
 ### Procesar correos y registrar tareas
 
 Usá `/procesar_correos` para analizar los avisos `.MSG` que reciba el bot y evitar cargar la información de forma manual. El aviso generado se envía automáticamente por correo a los contactos del cliente.

--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -39,6 +39,7 @@ from .handlers import (
     listar_tareas,
     detectar_tarea_mail,
     procesar_correos,
+    reenviar_aviso,
 )
 
 logger = logging.getLogger(__name__)
@@ -81,6 +82,7 @@ class SandyBot:
         self.app.add_handler(CommandHandler("listar_tareas", listar_tareas))
         self.app.add_handler(CommandHandler("detectar_tarea", detectar_tarea_mail))
         self.app.add_handler(CommandHandler("procesar_correos", procesar_correos))
+        self.app.add_handler(CommandHandler("reenviar_aviso", reenviar_aviso))
 
         # Callbacks de botones
         self.app.add_handler(CallbackQueryHandler(callback_handler))

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -29,6 +29,7 @@ from .carriers import listar_carriers, agregar_carrier, eliminar_carrier
 from .tarea_programada import registrar_tarea_programada
 from .detectar_tarea_mail import detectar_tarea_mail
 from .procesar_correos import procesar_correos
+from .reenviar_aviso import reenviar_aviso
 from .listar_tareas import listar_tareas
 
 __all__ = [
@@ -67,4 +68,5 @@ __all__ = [
     "listar_tareas",
     "detectar_tarea_mail",
     "procesar_correos",
+    "reenviar_aviso",
 ]

--- a/Sandy bot/sandybot/handlers/reenviar_aviso.py
+++ b/Sandy bot/sandybot/handlers/reenviar_aviso.py
@@ -1,0 +1,118 @@
+import tempfile
+from pathlib import Path
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from ..utils import obtener_mensaje
+from ..registrador import responder_registrando
+from ..database import (
+    TareaProgramada,
+    TareaServicio,
+    Servicio,
+    Cliente,
+    Carrier,
+    SessionLocal,
+    obtener_cliente_por_nombre,
+)
+from ..email_utils import generar_archivo_msg, enviar_correo
+
+
+async def reenviar_aviso(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Reenvía el aviso generado para una tarea programada."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        return
+
+    user_id = update.effective_user.id
+    if not context.args or not context.args[0].isdigit():
+        await responder_registrando(
+            mensaje,
+            user_id,
+            mensaje.text or "reenviar_aviso",
+            "Usá: /reenviar_aviso <id_tarea> [carrier]",
+            "tareas",
+        )
+        return
+
+    tarea_id = int(context.args[0])
+    carrier_nombre = context.args[1] if len(context.args) > 1 else None
+
+    with SessionLocal() as session:
+        tarea = session.get(TareaProgramada, tarea_id)
+        if not tarea:
+            await responder_registrando(
+                mensaje,
+                user_id,
+                mensaje.text or "reenviar_aviso",
+                f"No existe la tarea {tarea_id}.",
+                "tareas",
+            )
+            return
+
+        rels = (
+            session.query(TareaServicio)
+            .filter(TareaServicio.tarea_id == tarea.id)
+            .all()
+        )
+        servicios = [session.get(Servicio, r.servicio_id) for r in rels]
+
+        cliente = None
+        for s in servicios:
+            if not s:
+                continue
+            if s.cliente_id:
+                cli = session.get(Cliente, s.cliente_id)
+            else:
+                cli = obtener_cliente_por_nombre(s.cliente)
+            if cli:
+                cliente = cli
+                break
+        if not cliente:
+            await responder_registrando(
+                mensaje,
+                user_id,
+                mensaje.text or "reenviar_aviso",
+                "No pude determinar el cliente asociado.",
+                "tareas",
+            )
+            return
+
+        carrier = None
+        if carrier_nombre:
+            carrier = (
+                session.query(Carrier).filter(Carrier.nombre == carrier_nombre).first()
+            )
+        elif tarea.carrier_id:
+            carrier = session.get(Carrier, tarea.carrier_id)
+        if not carrier:
+            ids = {s.carrier_id for s in servicios if s and s.carrier_id}
+            if len(ids) == 1:
+                carrier = session.get(Carrier, ids.pop())
+
+        nombre_arch = f"tarea_{tarea.id}.msg"
+        ruta = Path(tempfile.gettempdir()) / nombre_arch
+        generar_archivo_msg(tarea, cliente, [s for s in servicios if s], str(ruta))
+
+        cuerpo = ""
+        try:
+            cuerpo = Path(ruta).read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            pass
+        enviar_correo(
+            f"Aviso de tarea programada - {cliente.nombre}",
+            cuerpo,
+            cliente.id,
+            carrier.nombre if carrier else None,
+        )
+
+        if ruta.exists():
+            with open(ruta, "rb") as f:
+                await mensaje.reply_document(f, filename=nombre_arch)
+
+    await responder_registrando(
+        mensaje,
+        user_id,
+        mensaje.text or "reenviar_aviso",
+        f"Aviso {tarea_id} reenviado.",
+        "tareas",
+    )


### PR DESCRIPTION
## Summary
- crear handler `reenviar_aviso`
- registrar el nuevo comando en el bot
- exponerlo en `handlers.__init__`
- documentar el uso en README
- probar la funcionalidad

## Testing
- `bash setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684999c6915883308c236d7f6db6c3c0