### PR TITLE
Modificar email_utils y handlers

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -266,8 +266,13 @@ def generar_archivo_msg(
     cliente: Cliente,
     servicios: list[Servicio],
     ruta: str,
-) -> str:
+) -> tuple[str, str]:
     """Genera un archivo *.msg* (Outlook) o texto plano con la tarea programada.
+
+    Returns
+    -------
+    tuple[str, str]
+        Ruta del archivo generado y el texto completo del aviso.
 
     - Con ``win32`` + ``pythoncom`` disponibles → se crea un verdadero **MSG**,
       se establece asunto, cuerpo y se agrega firma (si existe).
@@ -342,7 +347,7 @@ def generar_archivo_msg(
                     os.remove(temp_txt)
                 except OSError:
                     pass
-            return ruta
+            return ruta, mail.Body
         except Exception as e:  # pragma: no cover
             logger.error("Error generando archivo MSG: %s", e)
         finally:
@@ -356,4 +361,4 @@ def generar_archivo_msg(
     # 📝 Fallback a texto plano
     with open(ruta, "w", encoding="utf-8") as f:
         f.write(contenido)
-    return ruta
+    return ruta, contenido

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -157,16 +157,10 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             session.commit()
 
         nombre_arch = f"tarea_{tarea.id}.msg"
-        ruta_msg = Path(tempfile.gettempdir()) / nombre_arch
-        generar_archivo_msg(
-            tarea, cliente, [s for s in servicios if s], str(ruta_msg)
+        ruta_path = Path(tempfile.gettempdir()) / nombre_arch
+        _, cuerpo = generar_archivo_msg(
+            tarea, cliente, [s for s in servicios if s], str(ruta_path)
         )
-
-        cuerpo = ""
-        try:
-            cuerpo = Path(ruta_msg).read_text(encoding="utf-8", errors="ignore")
-        except Exception:
-            pass
         enviar_correo(
             f"Aviso de tarea programada - {cliente.nombre}",
             cuerpo,
@@ -174,8 +168,8 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             carrier.nombre if carrier else None,
         )
 
-        if ruta_msg.exists():
-            with open(ruta_msg, "rb") as f:
+        if ruta_path.exists():
+            with open(ruta_path, "rb") as f:
                 await mensaje.reply_document(f, filename=nombre_arch)
         tareas.append(str(tarea.id))
 

--- a/Sandy bot/sandybot/handlers/reenviar_aviso.py
+++ b/Sandy bot/sandybot/handlers/reenviar_aviso.py
@@ -90,14 +90,10 @@ async def reenviar_aviso(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 carrier = session.get(Carrier, ids.pop())
 
         nombre_arch = f"tarea_{tarea.id}.msg"
-        ruta = Path(tempfile.gettempdir()) / nombre_arch
-        generar_archivo_msg(tarea, cliente, [s for s in servicios if s], str(ruta))
-
-        cuerpo = ""
-        try:
-            cuerpo = Path(ruta).read_text(encoding="utf-8", errors="ignore")
-        except Exception:
-            pass
+        ruta_path = Path(tempfile.gettempdir()) / nombre_arch
+        _, cuerpo = generar_archivo_msg(
+            tarea, cliente, [s for s in servicios if s], str(ruta_path)
+        )
         enviar_correo(
             f"Aviso de tarea programada - {cliente.nombre}",
             cuerpo,
@@ -105,8 +101,8 @@ async def reenviar_aviso(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             carrier.nombre if carrier else None,
         )
 
-        if ruta.exists():
-            with open(ruta, "rb") as f:
+        if ruta_path.exists():
+            with open(ruta_path, "rb") as f:
                 await mensaje.reply_document(f, filename=nombre_arch)
 
     await responder_registrando(

--- a/Sandy bot/sandybot/handlers/tarea_programada.py
+++ b/Sandy bot/sandybot/handlers/tarea_programada.py
@@ -88,14 +88,14 @@ async def registrar_tarea_programada(
             session.commit()
 
         nombre_arch = f"tarea_{tarea.id}.msg"
-        ruta = Path(tempfile.gettempdir()) / nombre_arch
-        generar_archivo_msg(tarea, cliente, [s for s in servicios if s], str(ruta))
+        ruta_path = Path(tempfile.gettempdir()) / nombre_arch
+        _, cuerpo = generar_archivo_msg(
+            tarea,
+            cliente,
+            [s for s in servicios if s],
+            str(ruta_path),
+        )
 
-        cuerpo = ""
-        try:
-            cuerpo = Path(ruta).read_text(encoding="utf-8", errors="ignore")
-        except Exception:
-            pass
         enviar_correo(
             f"Aviso de tarea programada - {cliente.nombre}",
             cuerpo,
@@ -103,8 +103,8 @@ async def registrar_tarea_programada(
             carrier.nombre if carrier else None,
         )
 
-        if ruta.exists():
-            with open(ruta, "rb") as f:
+        if ruta_path.exists():
+            with open(ruta_path, "rb") as f:
                 await mensaje.reply_document(f, filename=nombre_arch)
 
     await responder_registrando(

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -213,11 +213,11 @@ def test_generar_archivo_msg(tmp_path):
     )
 
     ruta = tmp_path / "aviso.msg"
-    email_utils.generar_archivo_msg(tarea, cli, [srv], str(ruta))
+    resultado_ruta, texto = email_utils.generar_archivo_msg(tarea, cli, [srv], str(ruta))
+    assert resultado_ruta == str(ruta)
     assert ruta.exists()
-    contenido = ruta.read_text(encoding="utf-8")
-    assert "Mantenimiento" in contenido
-    assert "Telco" in contenido
+    assert "Mantenimiento" in texto
+    assert "Telco" in texto
 
 
 def test_generar_archivo_msg_win32(tmp_path, monkeypatch):
@@ -278,9 +278,9 @@ def test_generar_archivo_msg_win32(tmp_path, monkeypatch):
     )
 
     ruta = tmp_path / "aviso.msg"
-    resultado = email_utils.generar_archivo_msg(tarea, cli, [srv], str(ruta))
+    resultado, texto = email_utils.generar_archivo_msg(tarea, cli, [srv], str(ruta))
     assert resultado == str(ruta)
     assert outlook.saved == (str(ruta), 3)
     assert ruta.exists()
-    assert "Telco2" in ruta.read_text(encoding="utf-8")
+    assert "Telco2" in texto
     assert not Path(str(ruta) + ".txt").exists()


### PR DESCRIPTION
## Summary
- devolver también el texto generado en `generar_archivo_msg`
- aprovechar ese texto al enviar avisos en varios handlers
- actualizar las pruebas correspondientes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849b01377788330ae50745e907f53e4