### PR TITLE
Incluir cuerpo al registrar correos

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -372,12 +372,12 @@ def generar_archivo_msg(
     with open(ruta, "w", encoding="utf-8") as f:
         f.write(contenido)
 
-    return ruta
+    return ruta, contenido
 
 
 async def procesar_correo_a_tarea(
     texto: str, cliente_nombre: str, carrier_nombre: str | None = None
-) -> tuple[TareaProgramada, Cliente, Path]:
+) -> tuple[TareaProgramada, Cliente, Path, str]:
     """Analiza ``texto`` con GPT y registra la tarea programada."""
 
     prompt = (
@@ -456,7 +456,8 @@ async def procesar_correo_a_tarea(
 
         nombre_arch = f"tarea_{tarea.id}.msg"
         ruta = Path(tempfile.gettempdir()) / nombre_arch
-        generar_archivo_msg(tarea, cliente, [s for s in servicios if s], str(ruta))
+        _, cuerpo = generar_archivo_msg(
+            tarea, cliente, [s for s in servicios if s], str(ruta)
+        )
 
-        return tarea, cliente, ruta
-    return ruta, contenido
+        return tarea, cliente, ruta, cuerpo

--- a/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
+++ b/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
@@ -70,7 +70,7 @@ async def detectar_tarea_mail(update: Update, context: ContextTypes.DEFAULT_TYPE
         contenido = partes[2]
 
     try:
-        tarea, cliente, ruta = await procesar_correo_a_tarea(
+        tarea, cliente, ruta, _ = await procesar_correo_a_tarea(
             contenido, cliente_nombre, carrier_nombre
         )
     except Exception as e:

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -76,21 +76,7 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             contenido = _leer_msg(ruta)
             if not contenido:
                 raise ValueError("Sin contenido")
-            prompt = (
-                "Extraé del siguiente correo los datos de la ventana de mantenimiento "
-                "y devolvé solo un JSON con las claves 'inicio', 'fin', 'tipo', "
-                "'afectacion' e 'ids' (lista de servicios).\n\n"
-                f"Correo:\n{contenido}"
-            )
-            esquema = {
-                "type": "object",
-                "properties": {
-
-        try:
-            contenido = _leer_msg(ruta)
-            if not contenido:
-                raise ValueError("Sin contenido")
-            tarea, cliente, ruta_msg = await procesar_correo_a_tarea(
+            tarea, cliente, ruta_msg, cuerpo = await procesar_correo_a_tarea(
                 contenido, cliente_nombre, carrier_nombre
             )
         except Exception as e:  # pragma: no cover - manejo simple
@@ -98,13 +84,6 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             os.remove(ruta)
             continue
         os.remove(ruta)
-
-        # Leer el cuerpo del .msg recién generado para enviarlo por correo
-        cuerpo = ""
-        try:
-            cuerpo = Path(ruta_msg).read_text(encoding="utf-8", errors="ignore")
-        except Exception:
-            pass
 
         enviar_correo(
             f"Aviso de tarea programada - {cliente.nombre}",


### PR DESCRIPTION
## Summary
- mejorar `procesar_correo_a_tarea` para entregar también el texto generado
- retornar la ruta correcta en lugar de la cadena que devuelve `generar_archivo_msg`
- usar el cuerpo devuelto por `procesar_correo_a_tarea` en `procesar_correos`
- actualizar `detectar_tarea_mail` para recibir el nuevo valor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b797f78083309abfe0eb57eaedea