### PR TITLE
Actualizar proceso de correos y retorno de tareas

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -372,13 +372,17 @@ def generar_archivo_msg(
     with open(ruta, "w", encoding="utf-8") as f:
         f.write(contenido)
 
-    return ruta
+    return ruta, contenido
 
 
 async def procesar_correo_a_tarea(
     texto: str, cliente_nombre: str, carrier_nombre: str | None = None
-) -> tuple[TareaProgramada, Cliente, Path]:
-    """Analiza ``texto`` con GPT y registra la tarea programada."""
+) -> tuple[TareaProgramada, Cliente, Path, str]:
+    """Analiza ``texto`` con GPT y registra la tarea programada.
+
+    Devuelve la tarea creada, el cliente asociado, la ruta al archivo generado
+    y el cuerpo del aviso resultante.
+    """
 
     prompt = (
         "Extraé del siguiente correo los datos de la ventana de mantenimiento y "
@@ -456,7 +460,12 @@ async def procesar_correo_a_tarea(
 
         nombre_arch = f"tarea_{tarea.id}.msg"
         ruta = Path(tempfile.gettempdir()) / nombre_arch
-        generar_archivo_msg(tarea, cliente, [s for s in servicios if s], str(ruta))
+        ruta_str, cuerpo = generar_archivo_msg(
+            tarea,
+            cliente,
+            [s for s in servicios if s],
+            str(ruta),
+        )
+        ruta_msg = Path(ruta_str)
 
-        return tarea, cliente, ruta
-    return ruta, contenido
+        return tarea, cliente, ruta_msg, cuerpo

--- a/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
+++ b/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
@@ -70,8 +70,10 @@ async def detectar_tarea_mail(update: Update, context: ContextTypes.DEFAULT_TYPE
         contenido = partes[2]
 
     try:
-        tarea, cliente, ruta = await procesar_correo_a_tarea(
-            contenido, cliente_nombre, carrier_nombre
+        tarea, cliente, ruta, _ = await procesar_correo_a_tarea(
+            contenido,
+            cliente_nombre,
+            carrier_nombre,
         )
     except Exception as e:
         logger.error("Fallo detectando tarea: %s", e)

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -76,35 +76,16 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             contenido = _leer_msg(ruta)
             if not contenido:
                 raise ValueError("Sin contenido")
-            prompt = (
-                "Extraé del siguiente correo los datos de la ventana de mantenimiento "
-                "y devolvé solo un JSON con las claves 'inicio', 'fin', 'tipo', "
-                "'afectacion' e 'ids' (lista de servicios).\n\n"
-                f"Correo:\n{contenido}"
-            )
-            esquema = {
-                "type": "object",
-                "properties": {
-
-        try:
-            contenido = _leer_msg(ruta)
-            if not contenido:
-                raise ValueError("Sin contenido")
-            tarea, cliente, ruta_msg = await procesar_correo_a_tarea(
-                contenido, cliente_nombre, carrier_nombre
+            tarea, cliente, ruta_msg, cuerpo = await procesar_correo_a_tarea(
+                contenido,
+                cliente_nombre,
+                carrier_nombre,
             )
         except Exception as e:  # pragma: no cover - manejo simple
             logger.error("Fallo procesando correo: %s", e)
             os.remove(ruta)
             continue
         os.remove(ruta)
-
-        # Leer el cuerpo del .msg recién generado para enviarlo por correo
-        cuerpo = ""
-        try:
-            cuerpo = Path(ruta_msg).read_text(encoding="utf-8", errors="ignore")
-        except Exception:
-            pass
 
         enviar_correo(
             f"Aviso de tarea programada - {cliente.nombre}",


### PR DESCRIPTION
## Summary
- devolver también el cuerpo del mensaje en `procesar_correo_a_tarea`
- ajustar llamadas en `procesar_correos` y `detectar_tarea_mail`
- eliminar lectura redundante desde el archivo
- mantener envío de correo y adjunto de Telegram

## Testing
- `bash setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b79b3950833099624a0d60d89003