### PR TITLE
Actualizar documentación de correos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 Este repositorio contiene el proyecto SandyBot. Para ejecutarlo se requiere
 instalar las dependencias listadas en `Sandy bot/requirements.txt`. Se recomienda usar
 la versión `openai>=1.0.0` para garantizar compatibilidad con la nueva
-API utilizada en `sandybot`. También se necesita `extract-msg` para leer los
-archivos `.msg` con el comando `/procesar_correos`.
-Desde esta versión el bot también acepta mensajes de voz, los descarga y
-transcribe automáticamente utilizando la API de OpenAI.
+API utilizada en `sandybot`. Es obligatorio instalar `extract-msg` para leer los
+adjuntos `.msg` y opcionalmente `pywin32`, que permite insertar la firma y
+generar un `.MSG` real desde Outlook. Desde esta versión el bot también acepta
+mensajes de voz, los descarga y los transcribe automáticamente utilizando la API
+de OpenAI.
 
 ## Variables de entorno
 
@@ -150,7 +151,9 @@ Al registrar una tarea se genera un archivo `.MSG` con los datos
 principales. Este aviso puede abrirse con Outlook y reenviarse o
 ajustarse antes de enviarlo. Si `pywin32` está presente, el sistema
 aplica la firma ubicada en `SIGNATURE_PATH` y aprovecha Outlook para
-formatear el mensaje.
+formatear el mensaje. Para leer los adjuntos es necesario instalar
+`extract-msg`; `pywin32` es opcional, pero permite crear un `.MSG`
+real con la firma incluida.
 Además Sandy envía el aviso por correo a los destinatarios configurados para el cliente o para el par (cliente, carrier) cuando corresponde.
 
 ### Reenviar un aviso de tarea
@@ -167,13 +170,23 @@ Además adjuntará el archivo `.MSG` en el chat para facilitar el reenvío manua
 
 ### Procesar correos y registrar tareas
 
-Usá `/procesar_correos` para analizar los avisos `.MSG` que reciba el bot y evitar cargar la información de forma manual. El aviso generado se envía automáticamente por correo a los contactos del cliente.
+Usá `/procesar_correos` para analizar los avisos `.MSG` que reciba el bot y evitar cargar la información de forma manual. El comando extrae los datos mediante GPT y reenvía automáticamente el aviso a los destinatarios configurados.
+
+Si `pywin32` está instalado los `.MSG` se crean con Outlook, por lo que podés abrirlos y editar el cuerpo antes de enviarlos. Sin esas librerías el bot genera un texto plano.
 
 Por ejemplo:
 ```bash
 /procesar_correos Cliente
 ```
-Luego adjuntá uno o varios archivos `.msg` con las ventanas de mantenimiento.
+Luego adjuntá uno o varios archivos `.msg` con las ventanas de mantenimiento. Un aviso típico luce así:
+
+```
+Estimado Cliente, nuestro partner nos da aviso de la siguiente tarea programada:
+Inicio: 2024-01-02 08:00
+Fin: 2024-01-02 10:00
+Tipo de tarea: Mantenimiento
+Servicios afectados: 42
+```
 
 ### Detectar tareas desde un correo
 


### PR DESCRIPTION
## Summary
- aclarar dependencias extract-msg y pywin32
- extender la sección de procesamiento de correos con detalles de funcionamiento
- mostrar ejemplo de aviso generado

## Testing
- `./setup_env.sh`
- `pytest -q` *(fallan varias pruebas)*

------
https://chatgpt.com/codex/tasks/task_e_6849b79ff09083308f4214406f588c1b