### PR TITLE
Implementar generación de informe SLA

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -372,7 +372,7 @@ def generar_archivo_msg(
     with open(ruta, "w", encoding="utf-8") as f:
         f.write(contenido)
 
-    return ruta
+    return ruta, contenido
 
 
 async def procesar_correo_a_tarea(

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -10,6 +10,7 @@ from .voice import voice_handler
 from .ingresos import iniciar_verificacion_ingresos, procesar_ingresos
 from .registro_ingresos import iniciar_registro_ingresos, guardar_registro
 from .repetitividad import procesar_repetitividad
+from .informe_sla import iniciar_informe_sla, procesar_informe_sla
 from .comparador import iniciar_comparador, recibir_tracking, procesar_comparacion
 from .cargar_tracking import iniciar_carga_tracking, guardar_tracking_servicio
 from .descargar_tracking import iniciar_descarga_tracking, enviar_tracking_servicio
@@ -64,6 +65,8 @@ __all__ = [
     "procesar_identificador_carrier",
     "iniciar_incidencias",
     "procesar_incidencias",
+    "iniciar_informe_sla",
+    "procesar_informe_sla",
     "agregar_destinatario",
     "eliminar_destinatario",
     "listar_destinatarios",

--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -109,10 +109,9 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await guardar_tracking_servicio(update, context)
 
     elif query.data == "informe_sla":
-        registrar_conversacion(query.from_user.id, "informe_sla", "No implementado", "callback")
-        await query.edit_message_text(
-            "🔧 Función 'Informe de SLA' aún no implementada."
-        )
+        from .informe_sla import iniciar_informe_sla
+        registrar_conversacion(query.from_user.id, "boton_informe_sla", "Inicio informe SLA", "callback")
+        await iniciar_informe_sla(update, context)
         
     elif query.data == "otro":
         user_id = query.from_user.id

--- a/Sandy bot/sandybot/handlers/document.py
+++ b/Sandy bot/sandybot/handlers/document.py
@@ -46,6 +46,10 @@ async def manejar_documento(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         if mode == "incidencias":
             await procesar_incidencias(update, context)
             return
+        if mode == "informe_sla":
+            from .informe_sla import procesar_informe_sla
+            await procesar_informe_sla(update, context)
+            return
 
         # Lógica para el procesamiento de documentos
         await update.message.reply_text("Procesamiento de documentos en desarrollo.")

--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -1,0 +1,133 @@
+"""Módulo para generar informes de SLA."""
+
+from telegram import Update
+from telegram.ext import ContextTypes
+import logging
+import tempfile
+import os
+import pandas as pd
+from docx import Document
+
+from sandybot.config import config
+from ..utils import obtener_mensaje
+from .estado import UserState
+from ..registrador import responder_registrando, registrar_conversacion
+
+RUTA_PLANTILLA = config.PLANTILLA_PATH
+
+logger = logging.getLogger(__name__)
+
+
+async def iniciar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Inicia la carga de archivos para el informe de SLA."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        logger.warning("No se recibió mensaje en iniciar_informe_sla")
+        return
+    user_id = update.effective_user.id
+    UserState.set_mode(user_id, "informe_sla")
+    context.user_data.clear()
+    context.user_data["archivos"] = []
+    await responder_registrando(
+        mensaje,
+        user_id,
+        "informe_sla",
+        "Enviá el Excel de reclamos y luego el de servicios para generar el informe.",
+        "informe_sla",
+    )
+
+
+async def procesar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Recibe los archivos de reclamos y servicios y genera el informe."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje or not mensaje.document:
+        logger.warning("No se recibió documento en procesar_informe_sla")
+        return
+    user_id = mensaje.from_user.id
+    doc = mensaje.document
+    if not doc.file_name.endswith(".xlsx"):
+        await responder_registrando(
+            mensaje,
+            user_id,
+            doc.file_name,
+            "🙄 Solo acepto archivos Excel (.xlsx).",
+            "informe_sla",
+        )
+        return
+
+    archivo = await doc.get_file()
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as tmp:
+        await archivo.download_to_drive(tmp.name)
+        context.user_data.setdefault("archivos", []).append(tmp.name)
+
+    if len(context.user_data["archivos"]) < 2:
+        await responder_registrando(
+            mensaje,
+            user_id,
+            doc.file_name,
+            "Archivo recibido. Enviá el Excel restante para continuar.",
+            "informe_sla",
+        )
+        return
+
+    reclamos_path, servicios_path = context.user_data["archivos"][:2]
+
+    try:
+        ruta_salida = _generar_documento_sla(reclamos_path, servicios_path)
+        nombre_final = os.path.basename(ruta_salida)
+        with open(ruta_salida, "rb") as docx_file:
+            await mensaje.reply_document(document=docx_file, filename=nombre_final)
+        registrar_conversacion(
+            user_id,
+            doc.file_name,
+            f"Documento {nombre_final} enviado",
+            "informe_sla",
+        )
+    except Exception as e:  # pragma: no cover - procesamiento externo
+        logger.error("Error generando informe SLA: %s", e)
+        await responder_registrando(
+            mensaje,
+            user_id,
+            doc.file_name,
+            "💥 Algo falló generando el informe de SLA.",
+            "informe_sla",
+        )
+    finally:
+        for ruta in context.user_data.get("archivos", []):
+            try:
+                os.remove(ruta)
+            except OSError:
+                pass
+        if "ruta_salida" in locals() and os.path.exists(ruta_salida):
+            os.remove(ruta_salida)
+        context.user_data.clear()
+        UserState.set_mode(user_id, "")
+
+
+def _generar_documento_sla(reclamos_xlsx: str, servicios_xlsx: str) -> str:
+    """Combina los datos de reclamos y servicios en un documento Word."""
+    reclamos_df = pd.read_excel(reclamos_xlsx)
+    servicios_df = pd.read_excel(servicios_xlsx)
+    if "Servicio" not in reclamos_df.columns:
+        reclamos_df.rename(columns={reclamos_df.columns[0]: "Servicio"}, inplace=True)
+    if "Servicio" not in servicios_df.columns:
+        servicios_df.rename(columns={servicios_df.columns[0]: "Servicio"}, inplace=True)
+
+    resumen = reclamos_df.groupby("Servicio").size().reset_index(name="Reclamos")
+    df = servicios_df.merge(resumen, on="Servicio", how="left")
+    df["Reclamos"] = df["Reclamos"].fillna(0).astype(int)
+
+    doc = Document(RUTA_PLANTILLA)
+    tabla = doc.add_table(rows=1, cols=2, style="Table Grid")
+    hdr = tabla.rows[0].cells
+    hdr[0].text = "Servicio"
+    hdr[1].text = "Reclamos"
+    for _, fila in df.iterrows():
+        row = tabla.add_row().cells
+        row[0].text = str(fila["Servicio"])
+        row[1].text = str(fila["Reclamos"])
+
+    nombre_archivo = "InformeSLA.docx"
+    ruta_salida = os.path.join(tempfile.gettempdir(), nombre_archivo)
+    doc.save(ruta_salida)
+    return ruta_salida

--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -509,13 +509,8 @@ async def _ejecutar_accion_natural(
         await iniciar_incidencias(update, context)
         return True
     elif accion == "informe_sla":
-        await responder_registrando(
-            update.message,
-            update.effective_user.id,
-            accion,
-            "🔧 Función 'Informe de SLA' aún no implementada.",
-            "informe_sla",
-        )
+        from .informe_sla import iniciar_informe_sla
+        await iniciar_informe_sla(update, context)
         return True
     elif accion == "start":
         from .start import start_handler

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -76,20 +76,6 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             contenido = _leer_msg(ruta)
             if not contenido:
                 raise ValueError("Sin contenido")
-            prompt = (
-                "Extraé del siguiente correo los datos de la ventana de mantenimiento "
-                "y devolvé solo un JSON con las claves 'inicio', 'fin', 'tipo', "
-                "'afectacion' e 'ids' (lista de servicios).\n\n"
-                f"Correo:\n{contenido}"
-            )
-            esquema = {
-                "type": "object",
-                "properties": {
-
-        try:
-            contenido = _leer_msg(ruta)
-            if not contenido:
-                raise ValueError("Sin contenido")
             tarea, cliente, ruta_msg = await procesar_correo_a_tarea(
                 contenido, cliente_nombre, carrier_nombre
             )

--- a/tests/test_clasificar_flujo.py
+++ b/tests/test_clasificar_flujo.py
@@ -70,6 +70,7 @@ def test_flujos_nuevos():
         "enviar_camaras_mail",
         "analizar_incidencias",
         "nueva_solicitud",
+        "informe_sla",
     ]
     for flujo in nuevos:
         assert _clasificar(flujo) == flujo
@@ -94,6 +95,7 @@ def _detectar(texto: str) -> str:
         "sandybot.handlers.cargar_tracking": ModuleType("sandybot.handlers.cargar_tracking"),
         "sandybot.handlers.repetitividad": ModuleType("sandybot.handlers.repetitividad"),
         "sandybot.handlers.id_carrier": ModuleType("sandybot.handlers.id_carrier"),
+        "sandybot.handlers.informe_sla": ModuleType("sandybot.handlers.informe_sla"),
     }
 
     stubs["telegram"].Update = object
@@ -116,6 +118,7 @@ def _detectar(texto: str) -> str:
     stubs["sandybot.handlers.cargar_tracking"].iniciar_carga_tracking = _a
     stubs["sandybot.handlers.repetitividad"].iniciar_repetitividad = _a
     stubs["sandybot.handlers.id_carrier"].iniciar_identificador_carrier = _a
+    stubs["sandybot.handlers.informe_sla"].iniciar_informe_sla = _a
 
     class CT:
         DEFAULT_TYPE = object()
@@ -156,6 +159,7 @@ def test_variantes_diccionario():
         "desc trk": "descargar_tracking",
         "env cams mail": "enviar_camaras_mail",
         "verfiar ingrsos": "verificar_ingresos",
+        "inf sla": "informe_sla",
     }
 
     for texto, esperado in ejemplos.items():


### PR DESCRIPTION
## Summary
- agregar `informe_sla.py` para solicitar y procesar archivos
- registrar el nuevo flujo en los handlers y en el menú
- actualizar detección de mensajes y callbacks
- corregir retorno de `generar_archivo_msg`
- ajustar `procesar_correos` para evitar errores
- añadir pruebas del flujo SLA

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b6d2b3108330a7cfe2c5f9489e92