### PR TITLE
Añadir ruta de plantilla SLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ El comportamiento de SandyBot se ajusta mediante varias variables de entorno:
 
 - `PLANTILLA_PATH`: ruta de la plantilla para los informes de repetitividad. Si
   no se define, se usa `C:\Metrotel\Sandy\plantilla_informe.docx`.
+- `SLA_TEMPLATE_PATH`: ruta del documento base para el informe de SLA. Por
+  defecto se aplica `C:\Metrotel\Sandy\Template Informe SLA.docx`.
 - `SIGNATURE_PATH`: ruta a la firma opcional que se agregará en los correos.
 - `GPT_MODEL`: modelo de OpenAI a emplear. Por defecto se aplica `gpt-4`.
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`: datos para el servidor
@@ -53,6 +55,12 @@ El documento base para generar los reportes de repetitividad se indica
 mediante la variable de entorno `PLANTILLA_PATH`. Si no se define, el
 código toma la ruta por defecto `C:\Metrotel\Sandy\plantilla_informe.docx`
 tal como se especifica en `config.py`.
+
+## Plantilla del informe de SLA
+
+Para los reportes de nivel de servicio se utiliza un archivo Word
+configurable por `SLA_TEMPLATE_PATH`. Si la variable no está presente,
+se recurre a `C:\Metrotel\Sandy\Template Informe SLA.docx`.
 
 ## Base de datos
 

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -80,6 +80,12 @@ class Config:
             "PLANTILLA_PATH",
             r"C:\\Metrotel\\Sandy\\plantilla_informe.docx"
         )
+        # Plantilla para informes de SLA
+        # "SLA_TEMPLATE_PATH" permite ajustar la ubicación sin tocar el código
+        self.SLA_PLANTILLA_PATH = os.getenv(
+            "SLA_TEMPLATE_PATH",
+            r"C:\\Metrotel\\Sandy\\Template Informe SLA.docx",
+        )
         # Firma opcional en correos
         self.SIGNATURE_PATH = os.getenv("SIGNATURE_PATH")
 

--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -1,0 +1,32 @@
+"""Handler para generar informes de SLA."""
+
+from telegram import Update
+from telegram.ext import ContextTypes
+from docx import Document
+
+from sandybot.config import config
+from ..utils import obtener_mensaje
+from ..registrador import responder_registrando, registrar_conversacion
+
+
+async def iniciar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Indica al usuario que envíe el Excel de datos para el informe."""
+    message = obtener_mensaje(update)
+    if not message:
+        return
+    await responder_registrando(
+        message,
+        update.effective_user.id,
+        "informe_sla",
+        "Enviá el archivo con los datos para procesar el informe de SLA.",
+        "informe_sla",
+    )
+
+
+def generar_informe_sla(path_excel: str) -> str:
+    """Crea el documento Word a partir de la plantilla definida en la configuración."""
+    doc = Document(config.SLA_PLANTILLA_PATH)
+    # Aquí se procesarían los datos del Excel y se completarían tablas o campos
+    output = path_excel.replace(".xlsx", "_SLA.docx")
+    doc.save(output)
+    return output


### PR DESCRIPTION
## Resumen
- agregar `SLA_PLANTILLA_PATH` en `config.py`
- documentar variable `SLA_TEMPLATE_PATH` en README
- crear handler `informe_sla.py` y cargar plantilla con la ruta configurada

## Testing
- `./setup_env.sh`
- `pytest -q` *(fallan varias pruebas de la base original)*

------
https://chatgpt.com/codex/tasks/task_e_6849b6dbe900833098a00e81f43231a5