### PR TITLE
Agregar doc de Informe SLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ El comportamiento de SandyBot se ajusta mediante varias variables de entorno:
 
 - `PLANTILLA_PATH`: ruta de la plantilla para los informes de repetitividad. Si
   no se define, se usa `C:\Metrotel\Sandy\plantilla_informe.docx`.
+- `SLA_TEMPLATE_PATH`: ruta de la plantilla para el Informe de SLA. Si no se define, se usa `C:\Metrotel\Sandy\Template Informe SLA.docx`.
 - `SIGNATURE_PATH`: ruta a la firma opcional que se agregará en los correos.
 - `GPT_MODEL`: modelo de OpenAI a emplear. Por defecto se aplica `gpt-4`.
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`: datos para el servidor
@@ -246,6 +247,17 @@ También podés incluirlo al instalar todas las dependencias:
 ```bash
 pip install -r requirements.txt
 ```
+
+## Informe de SLA
+
+Este flujo genera un reporte basado en el documento `Template Informe SLA.docx`, ubicado por defecto en `C:\Metrotel\Sandy`. Para iniciarlo presioná **Informe de SLA** en el menú principal o ejecutá `/informe_sla`.
+Al activarse se usa la plantilla indicada por `SLA_TEMPLATE_PATH`. Si no se define, se toma `C:\Metrotel\Sandy\Template Informe SLA.docx`.
+El archivo debe existir en formato `.docx`.
+
+```env
+SLA_TEMPLATE_PATH=/ruta/al/Template Informe SLA.docx
+```
+
 
 ## Enviar Excel por correo
 

--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -72,6 +72,7 @@ DB_NAME=sandybot
 DB_USER=your_db_user
 DB_PASSWORD=your_db_password
 PLANTILLA_PATH=C:\Metrotel\Sandy\plantilla_informe.docx
+SLA_TEMPLATE_PATH=C:\Metrotel\Sandy\Template Informe SLA.docx
 ```
 
 ## Uso
@@ -175,14 +176,38 @@ adicional.
    - Nota: la modificación automática del documento usa `win32com` y solo
      funciona en Windows. En otros sistemas puede generarse el archivo .docx
      sin esta modificación o realizar los cambios de forma manual.
+7. Informe de SLA
+   - Genera un resumen de nivel de servicio usando `Template Informe SLA.docx`
+   - Podés iniciarlo desde el botón **Informe de SLA** o con `/informe_sla`
 
-7. Consultas generales
+
+8. Consultas generales
    - Respuestas técnicas con GPT
    - Tono adaptado según interacciones (de cordial a muy malhumorado)
    - Registro de conversaciones
 
-## Contribuir
+## Informe de SLA
 
+Esta opcion genera un documento de nivel de servicio basado en `Template Informe SLA.docx`.
+Podes iniciarla desde el boton **Informe de SLA** o con el comando `/informe_sla`.
+La variable `SLA_TEMPLATE_PATH` permite indicar la ruta exacta de la plantilla y debe apuntar a un archivo `.docx`.
+
+```env
+SLA_TEMPLATE_PATH=/ruta/al/Template Informe SLA.docx
+```
+
+## Pruebas
+
+Para ejecutar la suite de tests primero corré `setup_env.sh`.
+Ese script instala las dependencias en `.venv` y configura `PYTHONPATH`.
+Luego podés lanzar `pytest` normalmente.
+
+```bash
+./setup_env.sh
+pytest
+```
+
+## Contribuir
 1. Fork del repositorio
 2. Crear rama (`git checkout -b feature/nombre`)
 3. Commit cambios (`git commit -am 'Add: descripción'`)


### PR DESCRIPTION
## Summary
- documentar variable `SLA_TEMPLATE_PATH`
- explicar flujo "Informe de SLA" en ambos README
- indicar uso de `setup_env.sh` antes de correr las pruebas

## Testing
- `./setup_env.sh`
- `pytest -q` *(falla: ValueError en algunos tests)*

------
https://chatgpt.com/codex/tasks/task_e_6849b6eb8b50833093a2fac9c10ebbff