### PR TITLE
Elimina import duplicado

### DIFF
--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -10,7 +10,6 @@ from .voice import voice_handler
 from .ingresos import iniciar_verificacion_ingresos, procesar_ingresos
 from .registro_ingresos import iniciar_registro_ingresos, guardar_registro
 from .repetitividad import procesar_repetitividad
-from .informe_sla import procesar_informe_sla
 from .informe_sla import iniciar_informe_sla, procesar_informe_sla
 from .comparador import iniciar_comparador, recibir_tracking, procesar_comparacion
 from .cargar_tracking import iniciar_carga_tracking, guardar_tracking_servicio
@@ -51,7 +50,6 @@ __all__ = [
     "iniciar_registro_ingresos",
     "guardar_registro",
     "procesar_repetitividad",
-    "procesar_informe_sla",
     "iniciar_comparador",
     "recibir_tracking",
     "procesar_comparacion",


### PR DESCRIPTION
## Resumen
- corregir el import duplicado de `informe_sla`
- limpiar la lista `__all__`

## Testing
- `python -m py_compile 'Sandy bot/sandybot/handlers/__init__.py'`
- `pytest -q` *(falla: IndentationError en `informe_sla.py`)*

------
https://chatgpt.com/codex/tasks/task_e_6849c6a1b3c88330b31b646617f509ed