### PR TITLE
Corregir generación de Informe SLA

### DIFF
--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -27,6 +27,7 @@ from .handlers import (
     iniciar_carga_tracking,
     iniciar_descarga_tracking,
     iniciar_envio_camaras_mail,
+    iniciar_informe_sla,
 )
 from .handlers import (
     agregar_destinatario,
@@ -83,6 +84,7 @@ class SandyBot:
         self.app.add_handler(CommandHandler("detectar_tarea", detectar_tarea_mail))
         self.app.add_handler(CommandHandler("procesar_correos", procesar_correos))
         self.app.add_handler(CommandHandler("reenviar_aviso", reenviar_aviso))
+        self.app.add_handler(CommandHandler("informe_sla", iniciar_informe_sla))
 
         # Callbacks de botones
         self.app.add_handler(CallbackQueryHandler(callback_handler))

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -85,7 +85,7 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 raise ValueError("Sin contenido")
 
             # Procesa correo → registra tarea y genera .msg
-            tarea, cliente, ruta_msg = await procesar_correo_a_tarea(
+            tarea, cliente, ruta_msg, cuerpo = await procesar_correo_a_tarea(
                 contenido, cliente_nombre, carrier_nombre
             )
         except Exception as e:  # pragma: no cover
@@ -97,12 +97,7 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             if os.path.exists(ruta_tmp):
                 os.remove(ruta_tmp)
 
-        # Leemos cuerpo para reenviar por mail
-        cuerpo = ""
-        try:
-            cuerpo = Path(ruta_msg).read_text(encoding="utf-8", errors="ignore")
-        except Exception:
-            pass
+        # ``cuerpo`` ya contiene el texto del aviso generado
 
         # Envía aviso a destinatarios del cliente
         enviar_correo(


### PR DESCRIPTION
## Summary
- reparar la plantilla de `informe_sla` y su flujo de archivos
- exponer comando `/informe_sla` en el bot
- ajustar `procesar_correos` para cambios en `procesar_correo_a_tarea`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c5072f848330b229c9ee270a0322