### PR TITLE
Corrige uso de cuerpo devuelto en procesar_correos

### DIFF
--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
-from pathlib import Path
 
 from telegram import Update
 from telegram.ext import ContextTypes
@@ -85,7 +84,7 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 raise ValueError("Sin contenido")
 
             # Procesa correo → registra tarea y genera .msg
-            tarea, cliente, ruta_msg = await procesar_correo_a_tarea(
+            tarea, cliente, ruta_msg, cuerpo = await procesar_correo_a_tarea(
                 contenido, cliente_nombre, carrier_nombre
             )
         except Exception as e:  # pragma: no cover
@@ -96,13 +95,6 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             # Eliminamos el .msg original descargado
             if os.path.exists(ruta_tmp):
                 os.remove(ruta_tmp)
-
-        # Leemos cuerpo para reenviar por mail
-        cuerpo = ""
-        try:
-            cuerpo = Path(ruta_msg).read_text(encoding="utf-8", errors="ignore")
-        except Exception:
-            pass
 
         # Envía aviso a destinatarios del cliente
         enviar_correo(


### PR DESCRIPTION
## Summary
- ajusta la llamada a `procesar_correo_a_tarea` para recibir el texto del aviso
- se elimina la lectura posterior del archivo `.msg`
- se mantiene el envío de correos usando el cuerpo recibido

## Testing
- `bash setup_env.sh`
- `pytest -k 'procesar_correos'`

------
https://chatgpt.com/codex/tasks/task_e_6849c972fbb48330904a571ea06169c3