### PR TITLE
Valida plantilla SLA

### DIFF
--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -90,6 +90,15 @@ async def procesar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYP
             f"Documento {os.path.basename(ruta_final)} enviado",
             "informe_sla",
         )
+    except ValueError as e:
+        logger.error("Error generando informe SLA: %s", e)
+        await responder_registrando(
+            mensaje,
+            update.effective_user.id,
+            os.path.basename(tmp_paths[0]),
+            str(e),
+            "informe_sla",
+        )
     except Exception as e:  # pragma: no cover
         logger.error("Error generando informe SLA: %s", e)
         await responder_registrando(
@@ -135,10 +144,10 @@ def _generar_documento_sla(reclamos_xlsx: str, servicios_xlsx: str) -> str:
     df["Reclamos"] = df["Reclamos"].fillna(0).astype(int)
 
     # Documento base
-    if RUTA_PLANTILLA and os.path.exists(RUTA_PLANTILLA):
-        doc = Document(RUTA_PLANTILLA)
-    else:
-        doc = Document()
+    if not (RUTA_PLANTILLA and os.path.exists(RUTA_PLANTILLA)):
+        logger.error("Plantilla de SLA no encontrada: %s", RUTA_PLANTILLA)
+        raise ValueError("Plantilla de SLA no encontrada")
+    doc = Document(RUTA_PLANTILLA)
 
     doc.add_heading(f"Informe SLA {mes} {anio}", level=0)
 

--- a/tests/test_informe_sla.py
+++ b/tests/test_informe_sla.py
@@ -83,6 +83,9 @@ spec.loader.exec_module(informe)
 
 
 def test_procesar_informe_sla(tmp_path):
+    template = tmp_path / "template.docx"
+    Document().save(template)
+    informe.RUTA_PLANTILLA = str(template)
     reclamos = pd.DataFrame({
         "ID Servicio": [1, 1, 2],
         "Fecha": pd.to_datetime(["2024-05-01", "2024-05-02", "2024-05-03"]),
@@ -114,5 +117,8 @@ def test_procesar_informe_sla(tmp_path):
     doc = Document(ruta)
     titulo = doc.paragraphs[0].text
     assert "Informe SLA" in titulo
-    assert "Servicio 1" in doc.paragraphs[1].text
-    assert "Servicio 2" in doc.paragraphs[3].text
+    tabla = doc.tables[0]
+    assert tabla.cell(1, 0).text == "1"
+    assert tabla.cell(1, 1).text == "2"
+    assert tabla.cell(2, 0).text == "2"
+    assert tabla.cell(2, 1).text == "1"


### PR DESCRIPTION
## Resumen
- validar la existencia de la plantilla antes de generar el informe SLA
- reportar al usuario cuando falta la plantilla
- actualizar la prueba de `informe_sla` para usar una plantilla temporal

## Testing
- `./setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849cb9cf8b88330a8c9e8d9345c899b