### PR TITLE
Add custom text blocks to SLA report

### DIFF
--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -47,71 +47,140 @@ async def iniciar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYPE
 
 # ────────────────────────── FLUJO DE PROCESO ─────────────────────────
 async def procesar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Recibe los archivos de reclamos y servicios y genera el informe SLA."""
+    """Gestiona la generación del informe SLA en múltiples pasos."""
     mensaje = obtener_mensaje(update)
     if not mensaje:
         logger.warning("No se recibió mensaje en procesar_informe_sla")
         return
 
-    docs: list = []
-    if getattr(mensaje, "document", None):
-        docs.append(mensaje.document)
-    docs.extend(getattr(mensaje, "documents", []))
+    user_id = update.effective_user.id
 
-    # Debemos recibir al menos dos Excel
-    if len(docs) < 2:
+    # ───── Paso inicial: recepción de archivos Excel ─────
+    if not context.user_data.get("archivos"):
+        docs: list = []
+        if getattr(mensaje, "document", None):
+            docs.append(mensaje.document)
+        docs.extend(getattr(mensaje, "documents", []))
+
+        if len(docs) < 2:
+            await responder_registrando(
+                mensaje,
+                user_id,
+                getattr(docs[0], "file_name", getattr(mensaje, "text", "")),
+                "Adjuntá los Excel de reclamos y servicios.",
+                "informe_sla",
+            )
+            return
+
+        tmp_paths: list[str] = []
+        for doc in docs[:2]:
+            archivo = await doc.get_file()
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as tmp:
+                await archivo.download_to_drive(tmp.name)
+                tmp_paths.append(tmp.name)
+
+        context.user_data["archivos"] = tmp_paths
+        context.user_data["esperando_eventos"] = True
         await responder_registrando(
             mensaje,
-            update.effective_user.id,
-            getattr(docs[0], "file_name", mensaje.text or ""),
-            "Adjuntá los Excel de reclamos y servicios.",
+            user_id,
+            docs[0].file_name,
+            "Escribí los eventos sucedidos de mayor impacto en SLA.",
             "informe_sla",
         )
         return
 
-    # Descarga temporal de ambos archivos
-    tmp_paths: list[str] = []
-    for doc in docs[:2]:
-        archivo = await doc.get_file()
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as tmp:
-            await archivo.download_to_drive(tmp.name)
-            tmp_paths.append(tmp.name)
-
-    try:
-        # Generar documento Word
-        ruta_final = _generar_documento_sla(tmp_paths[0], tmp_paths[1])
-
-        with open(ruta_final, "rb") as f:
-            await mensaje.reply_document(f, filename=os.path.basename(ruta_final))
-
-        registrar_conversacion(
-            update.effective_user.id,
-            "informe_sla",
-            f"Documento {os.path.basename(ruta_final)} enviado",
-            "informe_sla",
-        )
-    except Exception as e:  # pragma: no cover
-        logger.error("Error generando informe SLA: %s", e)
+    # ───── Paso eventos ─────
+    if context.user_data.get("esperando_eventos"):
+        context.user_data["eventos"] = getattr(mensaje, "text", "")
+        context.user_data["esperando_eventos"] = False
+        context.user_data["esperando_conclusion"] = True
         await responder_registrando(
             mensaje,
-            update.effective_user.id,
-            os.path.basename(tmp_paths[0]),
-            "💥 Algo falló generando el informe de SLA.",
+            user_id,
+            getattr(mensaje, "text", ""),
+            "Indicá la conclusión.",
             "informe_sla",
         )
-    finally:
-        # Limpieza de archivos temporales y estado
-        for p in tmp_paths:
-            try:
-                os.remove(p)
-            except OSError:
-                pass
-        UserState.set_mode(update.effective_user.id, "")
+        return
+
+    # ───── Paso conclusión ─────
+    if context.user_data.get("esperando_conclusion"):
+        context.user_data["conclusion"] = getattr(mensaje, "text", "")
+        context.user_data["esperando_conclusion"] = False
+        context.user_data["esperando_propuesta"] = True
+        await responder_registrando(
+            mensaje,
+            user_id,
+            getattr(mensaje, "text", ""),
+            "¿Cuál es la propuesta de mejora?",
+            "informe_sla",
+        )
+        return
+
+    # ───── Paso propuesta y generación final ─────
+    if context.user_data.get("esperando_propuesta"):
+        context.user_data["propuesta"] = getattr(mensaje, "text", "")
+        context.user_data["esperando_propuesta"] = False
+
+        eventos = context.user_data.get("eventos")
+        conclusion = context.user_data.get("conclusion")
+        propuesta = context.user_data.get("propuesta")
+        rec, serv = context.user_data.get("archivos", [None, None])
+
+        try:
+            ruta_final = _generar_documento_sla(rec, serv, eventos, conclusion, propuesta)
+            with open(ruta_final, "rb") as f:
+                await mensaje.reply_document(f, filename=os.path.basename(ruta_final))
+
+            registrar_conversacion(
+                user_id,
+                "informe_sla",
+                f"Documento {os.path.basename(ruta_final)} enviado",
+                "informe_sla",
+            )
+        except Exception as e:  # pragma: no cover
+            logger.error("Error generando informe SLA: %s", e)
+            await responder_registrando(
+                mensaje,
+                user_id,
+                os.path.basename(rec or ""),
+                "💥 Algo falló generando el informe de SLA.",
+                "informe_sla",
+            )
+        finally:
+            for p in context.user_data.get("archivos", []):
+                try:
+                    os.remove(p)
+                except OSError:
+                    pass
+            context.user_data.clear()
+            UserState.set_mode(user_id, "")
+        return
+
+    # Estado no reconocido
+    await responder_registrando(
+        mensaje,
+        user_id,
+        getattr(mensaje, "text", ""),
+        "Adjuntá los archivos de reclamos y servicios para comenzar.",
+        "informe_sla",
+    )
 
 
 # ─────────────────────── FUNCIÓN GENERADORA DE WORD ───────────────────
-def _generar_documento_sla(reclamos_xlsx: str, servicios_xlsx: str) -> str:
-    """Combina reclamos y servicios en un documento Word usando la plantilla (si existe)."""
+def _generar_documento_sla(
+    reclamos_xlsx: str,
+    servicios_xlsx: str,
+    eventos: str | None = None,
+    conclusion: str | None = None,
+    propuesta: str | None = None,
+) -> str:
+    """Combina reclamos y servicios en un documento Word.
+
+    Si ``eventos``, ``conclusion`` o ``propuesta`` se indican, se insertan en
+    los párrafos correspondientes de la plantilla.
+    """
     reclamos_df = pd.read_excel(reclamos_xlsx)
     servicios_df = pd.read_excel(servicios_xlsx)
 
@@ -152,6 +221,25 @@ def _generar_documento_sla(reclamos_xlsx: str, servicios_xlsx: str) -> str:
         row = tabla.add_row().cells
         row[0].text = str(fila["Servicio"])
         row[1].text = str(fila["Reclamos"])
+
+    # Insertar textos personalizados si la plantilla tiene las etiquetas
+    etiquetas = {
+        "Eventos sucedidos de mayor impacto en SLA:": eventos,
+        "Conclusión:": conclusion,
+        "Propuesta de mejora:": propuesta,
+    }
+    encontrados = set()
+    for p in doc.paragraphs:
+        texto = p.text.strip()
+        for etiqueta, contenido in etiquetas.items():
+            if texto.startswith(etiqueta):
+                p.text = f"{etiqueta} {contenido or ''}"
+                encontrados.add(etiqueta)
+                break
+    # Si alguna etiqueta no existe en la plantilla, la agregamos al final
+    for etiqueta, contenido in etiquetas.items():
+        if etiqueta not in encontrados and contenido:
+            doc.add_paragraph(f"{etiqueta} {contenido}")
 
     # Guardado temporal
     nombre_arch = "InformeSLA.docx"

--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -116,6 +116,11 @@ async def message_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await _manejar_comparador(update, context, mensaje_usuario)
             return
 
+        if mode == "informe_sla":
+            from .informe_sla import procesar_informe_sla
+            await procesar_informe_sla(update, context)
+            return
+
         if mode == "ingresos":
             if context.user_data.get("esperando_opcion"):
                 await _manejar_opcion_ingresos(update, context, mensaje_usuario)


### PR DESCRIPTION
## Summary
- allow calling `_generar_documento_sla` with optional text sections
- insert those sections when building the document
- request the texts when the user uploads both Excel files
- route text messages in SLA mode to the same handler
- adapt unit test to new dialogue

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849cba7705c8330b6f098c1aeb0b44b