### PR TITLE
Manejo de archivos .msg en detectar_tarea_mail

### DIFF
--- a/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
+++ b/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
@@ -10,6 +10,7 @@ from telegram.ext import ContextTypes
 from ..utils import obtener_mensaje
 from ..email_utils import procesar_correo_a_tarea
 from ..registrador import responder_registrando
+from .procesar_correos import _leer_msg
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,13 @@ async def detectar_tarea_mail(update: Update, context: ContextTypes.DEFAULT_TYPE
             await archivo.download_to_drive(tmp.name)
             ruta = tmp.name
         try:
-            contenido = Path(ruta).read_text(encoding="utf-8", errors="ignore")
+            nombre = (mensaje.document.file_name or "").lower()
+            if nombre.endswith(".msg"):
+                contenido = _leer_msg(ruta)
+            else:
+                contenido = Path(ruta).read_text(
+                    encoding="utf-8", errors="ignore"
+                )
         except Exception as e:
             logger.error("Error leyendo adjunto: %s", e)
             os.remove(ruta)


### PR DESCRIPTION
## Resumen
- leer los adjuntos `.msg` usando `_leer_msg`
- mantener lectura de texto para los demás formatos

## Testing
- `python -m py_compile 'Sandy bot/sandybot/handlers/detectar_tarea_mail.py'`

------
https://chatgpt.com/codex/tasks/task_e_6849d5bea4d48330b4a3e2b2a9f6755c