### PR TITLE
Acepta Excel del informe SLA en mensajes separados

### DIFF
--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -165,3 +165,8 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif query.data == "comparador_procesar":
         registrar_conversacion(query.from_user.id, "comparador_procesar", "Procesar", "callback")
         await procesar_comparacion(update, context)
+
+    elif query.data == "sla_procesar":
+        from .informe_sla import preguntar_eventos_sla
+        registrar_conversacion(query.from_user.id, "sla_procesar", "Procesar informe", "callback")
+        await preguntar_eventos_sla(update, context)

--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -8,7 +8,7 @@ import tempfile
 
 import pandas as pd
 from docx import Document
-from telegram import Update
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 
 from sandybot.config import config
@@ -33,7 +33,8 @@ async def iniciar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYPE
     user_id = update.effective_user.id
     UserState.set_mode(user_id, "informe_sla")
     context.user_data.clear()
-    context.user_data["archivos"] = []
+    # Se reservan dos posiciones: 0 para reclamos y 1 para servicios
+    context.user_data["archivos"] = [None, None]
 
     await responder_registrando(
         mensaje,
@@ -55,37 +56,48 @@ async def procesar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYP
     user_id = update.effective_user.id
 
     # ───── Paso inicial: recepción de los 2 Excel ─────
-    if not context.user_data.get("archivos"):
-        docs: list = []
-        if getattr(mensaje, "document", None):
-            docs.append(mensaje.document)
-        docs.extend(getattr(mensaje, "documents", []))
+    archivos = context.user_data.setdefault("archivos", [None, None])
+    docs: list = []
+    if getattr(mensaje, "document", None):
+        docs.append(mensaje.document)
+    docs.extend(getattr(mensaje, "documents", []))
 
-        if len(docs) < 2:
-            await responder_registrando(
-                mensaje,
-                user_id,
-                getattr(docs[0], "file_name", getattr(mensaje, "text", "")),
-                "Adjuntá los Excel de reclamos y servicios.",
-                "informe_sla",
-            )
-            return
-
-        tmp_paths: list[str] = []
-        for doc in docs[:2]:
+    if docs:
+        for doc in docs:
             archivo = await doc.get_file()
             with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as tmp:
                 await archivo.download_to_drive(tmp.name)
-                tmp_paths.append(tmp.name)
+                nombre = doc.file_name.lower()
+                if "recl" in nombre and archivos[0] is None:
+                    archivos[0] = tmp.name
+                elif "serv" in nombre and archivos[1] is None:
+                    archivos[1] = tmp.name
+                elif archivos[0] is None:
+                    archivos[0] = tmp.name
+                else:
+                    archivos[1] = tmp.name
 
-        context.user_data["archivos"] = tmp_paths
-        context.user_data["esperando_eventos"] = True
+        context.user_data["archivos"] = archivos
+        if None in archivos:
+            falta = "reclamos" if archivos[0] is None else "servicios"
+            await responder_registrando(
+                mensaje,
+                user_id,
+                docs[-1].file_name,
+                f"Archivo guardado. Falta el Excel de {falta}.",
+                "informe_sla",
+            )
+            return
+        keyboard = InlineKeyboardMarkup(
+            [[InlineKeyboardButton("Procesar informe", callback_data="sla_procesar")]]
+        )
         await responder_registrando(
             mensaje,
             user_id,
-            docs[0].file_name,
-            "Escribí los eventos sucedidos de mayor impacto en SLA.",
+            docs[-1].file_name,
+            "Archivos cargados. Presioná *Procesar informe*.",
             "informe_sla",
+            reply_markup=keyboard,
         )
         return
 
@@ -164,6 +176,25 @@ async def procesar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYP
         user_id,
         getattr(mensaje, "text", ""),
         "Adjuntá los archivos de reclamos y servicios para comenzar.",
+        "informe_sla",
+    )
+
+
+# ──────────────────────── CONTINUACIÓN VIA CALLBACK ───────────────────
+async def preguntar_eventos_sla(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Inicia la etapa de descripción de eventos tras recibir ambos Excel."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        logger.warning("No se recibió mensaje en preguntar_eventos_sla")
+        return
+
+    user_id = update.effective_user.id
+    context.user_data["esperando_eventos"] = True
+    await responder_registrando(
+        mensaje,
+        user_id,
+        "sla_procesar",
+        "Escribí los eventos sucedidos de mayor impacto en SLA.",
         "informe_sla",
     )
 


### PR DESCRIPTION
## Summary
- permitir subir archivos de reclamos y servicios por separado
- avisar cuál falta y ofrecer botón *Procesar informe*
- iniciar etapa de eventos al pulsar el botón
- adaptar el test del flujo SLA para reflejar el nuevo comportamiento

## Testing
- `bash setup_env.sh > /tmp/setup.log && tail -n 20 /tmp/setup.log`
- `source .venv/bin/activate && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d734514883308c5cff44cb2f6e20