### PR TITLE
Implement SLA processing button

### DIFF
--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -191,8 +191,8 @@ adicional.
 
 Esta opcion genera un documento de nivel de servicio basado en `Template Informe SLA.docx`.
 Podes iniciarla desde el boton **Informe de SLA** o con el comando `/informe_sla`.
-El bot pedirá primero el Excel de **reclamos** y a continuación el de **servicios**.
-Una vez recibidos ambos archivos solicitará escribir los textos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora**.
+El bot pedirá primero el Excel de **reclamos** y luego el de **servicios**.
+Tras recibirlos mostrará el botón *Procesar 🚀*. Al presionarlo solicitará los textos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora**.
 La variable `SLA_TEMPLATE_PATH` permite indicar la ruta exacta de la plantilla y debe apuntar a un archivo `.docx`.
 
 ```env

--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -165,3 +165,8 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif query.data == "comparador_procesar":
         registrar_conversacion(query.from_user.id, "comparador_procesar", "Procesar", "callback")
         await procesar_comparacion(update, context)
+
+    elif query.data == "sla_procesar":
+        from .informe_sla import procesar_informe_sla
+        registrar_conversacion(query.from_user.id, "sla_procesar", "Procesar", "callback")
+        await procesar_informe_sla(update, context)


### PR DESCRIPTION
## Summary
- add callback `sla_procesar` to run SLA workflow
- show `Procesar 🚀` button when both Excel files are received
- request events, conclusion and proposal only after pressing the button
- update documentation and unit tests accordingly

## Testing
- `./setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d7395e388330984521ebf2c467d1