### PR TITLE
Permitir informe SLA con archivos en mensajes separados

### DIFF
--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -165,3 +165,8 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif query.data == "comparador_procesar":
         registrar_conversacion(query.from_user.id, "comparador_procesar", "Procesar", "callback")
         await procesar_comparacion(update, context)
+
+    elif query.data == "sla_procesar":
+        from .informe_sla import procesar_informe_sla
+        registrar_conversacion(query.from_user.id, "sla_procesar", "Procesar", "callback")
+        await procesar_informe_sla(update, context)


### PR DESCRIPTION
## Summary
- ajustamos `informe_sla.py` para aceptar los Excel por separado y
  mostrar un botón de procesamiento
- manejamos el nuevo callback `sla_procesar` en `callback.py`
- añadimos un stub de Telegram más completo en la prueba
- verificamos todo el flujo en `test_informe_sla.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d73e0d2083309b7553065d607d3c