### PR TITLE
Añadir encabezados descriptivos en módulos

### DIFF
--- a/Sandy bot/main.py
+++ b/Sandy bot/main.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: main.py
+# + Ubicación de archivo: Sandy bot/main.py
+# User-provided custom instructions
 """
 Punto de entrada principal de la aplicación
 """

--- a/Sandy bot/sandybot/__init__.py
+++ b/Sandy bot/sandybot/__init__.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: __init__.py
+# + Ubicación de archivo: Sandy bot/sandybot/__init__.py
+# User-provided custom instructions
 """
 SandyBot - Telegram bot for fiber optic infrastructure management
 """

--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: bot.py
+# + Ubicación de archivo: Sandy bot/sandybot/bot.py
+# User-provided custom instructions
 """
 Módulo principal del bot Sandy
 """

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: config.py
+# + Ubicación de archivo: Sandy bot/sandybot/config.py
+# User-provided custom instructions
 """Configuración centralizada para el bot Sandy.
 
 Este módulo concentra la lectura de todas las variables de entorno

--- a/Sandy bot/sandybot/correo.py
+++ b/Sandy bot/sandybot/correo.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: correo.py
+# + Ubicación de archivo: Sandy bot/sandybot/correo.py
+# User-provided custom instructions
 import os
 import smtplib
 from email.message import EmailMessage

--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: database.py
+# + Ubicación de archivo: Sandy bot/sandybot/database.py
+# User-provided custom instructions
 from sqlalchemy import (
     create_engine,
     Column,

--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: email_utils.py
+# + Ubicación de archivo: Sandy bot/sandybot/email_utils.py
+# User-provided custom instructions
 """Funciones utilitarias para el manejo de correos."""
 
 from pathlib import Path

--- a/Sandy bot/sandybot/gpt_handler.py
+++ b/Sandy bot/sandybot/gpt_handler.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: gpt_handler.py
+# + Ubicación de archivo: Sandy bot/sandybot/gpt_handler.py
+# User-provided custom instructions
 """
 Manejador de interacciones con GPT con soporte para cache y manejo de errores.
 """

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: __init__.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/__init__.py
+# User-provided custom instructions
 """
 Handlers del bot Sandy
 """

--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: callback.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/callback.py
+# User-provided custom instructions
 """
 Handler para callbacks de botones
 """

--- a/Sandy bot/sandybot/handlers/cargar_tracking.py
+++ b/Sandy bot/sandybot/handlers/cargar_tracking.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: cargar_tracking.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/cargar_tracking.py
+# User-provided custom instructions
 """Handler para la carga de trackings en la base de datos."""
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes

--- a/Sandy bot/sandybot/handlers/carriers.py
+++ b/Sandy bot/sandybot/handlers/carriers.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: carriers.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/carriers.py
+# User-provided custom instructions
 """Comandos para administrar carriers."""
 
 from telegram import Update

--- a/Sandy bot/sandybot/handlers/comparador.py
+++ b/Sandy bot/sandybot/handlers/comparador.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: comparador.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/comparador.py
+# User-provided custom instructions
 """
 Handler para la comparación de trazados de fibra óptica.
 """

--- a/Sandy bot/sandybot/handlers/descargar_camaras.py
+++ b/Sandy bot/sandybot/handlers/descargar_camaras.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: descargar_camaras.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/descargar_camaras.py
+# User-provided custom instructions
 """Handler para descargar las cámaras de un servicio en un Excel."""
 
 from telegram import Update

--- a/Sandy bot/sandybot/handlers/descargar_tracking.py
+++ b/Sandy bot/sandybot/handlers/descargar_tracking.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: descargar_tracking.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/descargar_tracking.py
+# User-provided custom instructions
 """Handler para descargar trackings guardados."""
 
 from telegram import Update

--- a/Sandy bot/sandybot/handlers/destinatarios.py
+++ b/Sandy bot/sandybot/handlers/destinatarios.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: destinatarios.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/destinatarios.py
+# User-provided custom instructions
 """Manejo de destinatarios para envíos de SandyBot"""
 
 from telegram import Update

--- a/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
+++ b/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: detectar_tarea_mail.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/detectar_tarea_mail.py
+# User-provided custom instructions
 """Detección automática de tareas programadas desde correos."""
 
 import logging

--- a/Sandy bot/sandybot/handlers/document.py
+++ b/Sandy bot/sandybot/handlers/document.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: document.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/document.py
+# User-provided custom instructions
 """
 Handler para el procesamiento de documentos.
 """

--- a/Sandy bot/sandybot/handlers/enviar_camaras_mail.py
+++ b/Sandy bot/sandybot/handlers/enviar_camaras_mail.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: enviar_camaras_mail.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/enviar_camaras_mail.py
+# User-provided custom instructions
 """Manejadores para enviar las cámaras de un servicio por correo electrónico."""
 
 from telegram import Update

--- a/Sandy bot/sandybot/handlers/estado.py
+++ b/Sandy bot/sandybot/handlers/estado.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: estado.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/estado.py
+# User-provided custom instructions
 """
 Manejo del estado de usuarios del bot
 """

--- a/Sandy bot/sandybot/handlers/id_carrier.py
+++ b/Sandy bot/sandybot/handlers/id_carrier.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: id_carrier.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/id_carrier.py
+# User-provided custom instructions
 """Handler para completar IDs de servicio o Carrier desde un Excel."""
 
 from telegram import Update

--- a/Sandy bot/sandybot/handlers/incidencias.py
+++ b/Sandy bot/sandybot/handlers/incidencias.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: incidencias.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/incidencias.py
+# User-provided custom instructions
 """Manejadores para el análisis de incidencias."""
 
 from telegram import Update

--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: informe_sla.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/informe_sla.py
+# User-provided custom instructions
 """Handler para generar informes de SLA."""
 
 from __future__ import annotations

--- a/Sandy bot/sandybot/handlers/ingresos.py
+++ b/Sandy bot/sandybot/handlers/ingresos.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: ingresos.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/ingresos.py
+# User-provided custom instructions
 """
 Handler para la verificación de ingresos.
 """

--- a/Sandy bot/sandybot/handlers/listar_tareas.py
+++ b/Sandy bot/sandybot/handlers/listar_tareas.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: listar_tareas.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/listar_tareas.py
+# User-provided custom instructions
 from datetime import datetime
 from telegram import Update
 from telegram.ext import ContextTypes

--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: message.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/message.py
+# User-provided custom instructions
 """
 Handler para mensajes de texto
 """

--- a/Sandy bot/sandybot/handlers/notion.py
+++ b/Sandy bot/sandybot/handlers/notion.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: notion.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/notion.py
+# User-provided custom instructions
 """
 Integración con Notion para registro de acciones pendientes
 """

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: procesar_correos.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/procesar_correos.py
+# User-provided custom instructions
 """Procesamiento masivo de correos .msg para registrar tareas."""
 
 from __future__ import annotations

--- a/Sandy bot/sandybot/handlers/reenviar_aviso.py
+++ b/Sandy bot/sandybot/handlers/reenviar_aviso.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: reenviar_aviso.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/reenviar_aviso.py
+# User-provided custom instructions
 import tempfile
 from pathlib import Path
 from telegram import Update

--- a/Sandy bot/sandybot/handlers/registro_ingresos.py
+++ b/Sandy bot/sandybot/handlers/registro_ingresos.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: registro_ingresos.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/registro_ingresos.py
+# User-provided custom instructions
 """Flujo para registrar ingresos a cámaras"""
 from datetime import datetime
 from telegram import Update

--- a/Sandy bot/sandybot/handlers/repetitividad.py
+++ b/Sandy bot/sandybot/handlers/repetitividad.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: repetitividad.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/repetitividad.py
+# User-provided custom instructions
 # Repetitividad.py
 """
 Handler para la generación de informes de repetitividad.

--- a/Sandy bot/sandybot/handlers/start.py
+++ b/Sandy bot/sandybot/handlers/start.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: start.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/start.py
+# User-provided custom instructions
 """
 Handler principal para el comando /start
 """

--- a/Sandy bot/sandybot/handlers/tarea_programada.py
+++ b/Sandy bot/sandybot/handlers/tarea_programada.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: tarea_programada.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/tarea_programada.py
+# User-provided custom instructions
 from datetime import datetime
 import tempfile
 from pathlib import Path

--- a/Sandy bot/sandybot/handlers/voice.py
+++ b/Sandy bot/sandybot/handlers/voice.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: voice.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/voice.py
+# User-provided custom instructions
 """Handler para mensajes de voz."""
 import logging
 import tempfile

--- a/Sandy bot/sandybot/incidencias.py
+++ b/Sandy bot/sandybot/incidencias.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: incidencias.py
+# + Ubicación de archivo: Sandy bot/sandybot/incidencias.py
+# User-provided custom instructions
 from docx import Document
 from pathlib import Path
 from .gpt_handler import gpt

--- a/Sandy bot/sandybot/logging_config.py
+++ b/Sandy bot/sandybot/logging_config.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: logging_config.py
+# + Ubicación de archivo: Sandy bot/sandybot/logging_config.py
+# User-provided custom instructions
 import logging
 from logging.handlers import RotatingFileHandler
 from .config import config

--- a/Sandy bot/sandybot/registrador.py
+++ b/Sandy bot/sandybot/registrador.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: registrador.py
+# + Ubicación de archivo: Sandy bot/sandybot/registrador.py
+# User-provided custom instructions
 # sandybot/registrador.py
 from datetime import datetime
 from .database import SessionLocal, Conversacion

--- a/Sandy bot/sandybot/tracking_parser.py
+++ b/Sandy bot/sandybot/tracking_parser.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: tracking_parser.py
+# + Ubicación de archivo: Sandy bot/sandybot/tracking_parser.py
+# User-provided custom instructions
 """Parser de trackings de fibra óptica."""
 
 from __future__ import annotations

--- a/Sandy bot/sandybot/utils.py
+++ b/Sandy bot/sandybot/utils.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: utils.py
+# + Ubicación de archivo: Sandy bot/sandybot/utils.py
+# User-provided custom instructions
 """
 Funciones de utilidad comunes para el bot
 """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# + Nombre de archivo: __init__.py
+# + Ubicación de archivo: tests/__init__.py
+# User-provided custom instructions

--- a/tests/telegram_stub.py
+++ b/tests/telegram_stub.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: telegram_stub.py
+# + Ubicación de archivo: tests/telegram_stub.py
+# User-provided custom instructions
 from types import ModuleType, SimpleNamespace
 from pathlib import Path
 import sys

--- a/tests/test_carriers.py
+++ b/tests/test_carriers.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_carriers.py
+# + Ubicación de archivo: tests/test_carriers.py
+# User-provided custom instructions
 import sys
 import importlib
 import asyncio

--- a/tests/test_clasificar_flujo.py
+++ b/tests/test_clasificar_flujo.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_clasificar_flujo.py
+# + Ubicación de archivo: tests/test_clasificar_flujo.py
+# User-provided custom instructions
 import sys
 import importlib
 import asyncio

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_database.py
+# + Ubicación de archivo: tests/test_database.py
+# User-provided custom instructions
 import os
 import sys
 import importlib

--- a/tests/test_destinatarios.py
+++ b/tests/test_destinatarios.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_destinatarios.py
+# + Ubicación de archivo: tests/test_destinatarios.py
+# User-provided custom instructions
 import sys
 import importlib
 import asyncio

--- a/tests/test_detectar_tarea_mail.py
+++ b/tests/test_detectar_tarea_mail.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_detectar_tarea_mail.py
+# + Ubicación de archivo: tests/test_detectar_tarea_mail.py
+# User-provided custom instructions
 import sys
 import importlib
 import asyncio

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_email.py
+# + Ubicación de archivo: tests/test_email.py
+# User-provided custom instructions
 import sys
 import os
 import importlib

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_email_utils.py
+# + Ubicación de archivo: tests/test_email_utils.py
+# User-provided custom instructions
 import sys
 import types
 import os

--- a/tests/test_gpt_cache.py
+++ b/tests/test_gpt_cache.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_gpt_cache.py
+# + Ubicación de archivo: tests/test_gpt_cache.py
+# User-provided custom instructions
 import sys
 from types import ModuleType
 from pathlib import Path

--- a/tests/test_incidencias.py
+++ b/tests/test_incidencias.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_incidencias.py
+# + Ubicación de archivo: tests/test_incidencias.py
+# User-provided custom instructions
 import sys
 import importlib
 import asyncio

--- a/tests/test_informe_sla.py
+++ b/tests/test_informe_sla.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_informe_sla.py
+# + Ubicación de archivo: tests/test_informe_sla.py
+# User-provided custom instructions
 import sys
 import importlib
 import asyncio

--- a/tests/test_listar_tareas.py
+++ b/tests/test_listar_tareas.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_listar_tareas.py
+# + Ubicación de archivo: tests/test_listar_tareas.py
+# User-provided custom instructions
 import sys
 import importlib
 import asyncio

--- a/tests/test_procesar_correos.py
+++ b/tests/test_procesar_correos.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_procesar_correos.py
+# + Ubicación de archivo: tests/test_procesar_correos.py
+# User-provided custom instructions
 import asyncio
 import importlib
 import sys

--- a/tests/test_tarea_programada.py
+++ b/tests/test_tarea_programada.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_tarea_programada.py
+# + Ubicación de archivo: tests/test_tarea_programada.py
+# User-provided custom instructions
 import sys
 import importlib
 import asyncio

--- a/tests/test_tracking_parser.py
+++ b/tests/test_tracking_parser.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_tracking_parser.py
+# + Ubicación de archivo: tests/test_tracking_parser.py
+# User-provided custom instructions
 import sys
 import os
 import importlib

--- a/tests/test_userstate.py
+++ b/tests/test_userstate.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_userstate.py
+# + Ubicación de archivo: tests/test_userstate.py
+# User-provided custom instructions
 import sys
 import os
 import importlib

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_utils.py
+# + Ubicación de archivo: tests/test_utils.py
+# User-provided custom instructions
 import sys
 from types import ModuleType
 from pathlib import Path

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: test_voice_handler.py
+# + Ubicación de archivo: tests/test_voice_handler.py
+# User-provided custom instructions
 import sys
 import importlib
 import asyncio


### PR DESCRIPTION
## Resumen
- se agregaron comentarios iniciales con nombre y ubicación de cada módulo
- se actualizaron los archivos en `Sandy bot/` y `tests/`

## Testing
- `bash setup_env.sh`
- `pytest -q` *(falla: test_procesar_informe_sla)*

------
https://chatgpt.com/codex/tasks/task_e_6849e004375883308bf466ac6c170045