### PR TITLE
Eliminar .msg temporales después de enviarlos

### DIFF
--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -130,6 +130,7 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         if ruta_msg.exists():
             with open(ruta_msg, "rb") as f:
                 await mensaje.reply_document(f, filename=ruta_msg.name)
+            os.remove(ruta_msg)
 
         tareas.append(str(tarea.id))
 

--- a/Sandy bot/sandybot/handlers/reenviar_aviso.py
+++ b/Sandy bot/sandybot/handlers/reenviar_aviso.py
@@ -2,6 +2,7 @@
 # + Ubicación de archivo: Sandy bot/sandybot/handlers/reenviar_aviso.py
 # User-provided custom instructions
 import tempfile
+import os
 from pathlib import Path
 from telegram import Update
 from telegram.ext import ContextTypes
@@ -107,6 +108,7 @@ async def reenviar_aviso(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         if ruta_path.exists():
             with open(ruta_path, "rb") as f:
                 await mensaje.reply_document(f, filename=nombre_arch)
+            os.remove(ruta_path)
 
     await responder_registrando(
         mensaje,

--- a/Sandy bot/sandybot/handlers/tarea_programada.py
+++ b/Sandy bot/sandybot/handlers/tarea_programada.py
@@ -3,6 +3,7 @@
 # User-provided custom instructions
 from datetime import datetime
 import tempfile
+import os
 from pathlib import Path
 from telegram import Update
 from telegram.ext import ContextTypes
@@ -109,6 +110,7 @@ async def registrar_tarea_programada(
         if ruta_path.exists():
             with open(ruta_path, "rb") as f:
                 await mensaje.reply_document(f, filename=nombre_arch)
+            os.remove(ruta_path)
 
     await responder_registrando(
         mensaje,

--- a/tests/test_procesar_correos.py
+++ b/tests/test_procesar_correos.py
@@ -204,7 +204,7 @@ def test_procesar_correos(tmp_path):
     assert rel.tarea_id == tarea.id
     assert rel.servicio_id == servicio.id
     ruta = tmp_path / f"tarea_{tarea.id}.msg"
-    assert ruta.exists()
+    assert not ruta.exists()
     assert msg.sent == ruta.name
     assert enviados["cid"] == cli.id
     assert "Mant" in enviados["cuerpo"]

--- a/tests/test_tarea_programada.py
+++ b/tests/test_tarea_programada.py
@@ -156,7 +156,7 @@ def test_registrar_tarea_programada(tmp_path):
     assert rels[-1].tarea_id == tareas[-1].id
     assert rels[-1].servicio_id == servicio.id
     ruta = tmp_path / f"tarea_{tareas[-1].id}.msg"
-    assert ruta.exists()
+    assert not ruta.exists()
     assert msg.documento == ruta.name
     assert enviados["cid"] == cli.id
     assert "Mantenimiento" in enviados["cuerpo"]
@@ -214,7 +214,7 @@ def test_reenviar_aviso(tmp_path):
     tempfile.gettempdir = orig_tmp
 
     ruta = tmp_path / f"tarea_{tarea.id}.msg"
-    assert ruta.exists()
+    assert not ruta.exists()
     assert msg.documento == ruta.name
     assert enviados["cid"] == cli.id
     assert "Mantenimiento" in enviados["cuerpo"]


### PR DESCRIPTION
## Resumen
- eliminar los archivos `.msg` una vez enviados en los handlers de correos
- actualizar los tests para reflejar la limpieza de estos archivos

## Testing
- `python -m py_compile 'Sandy bot/sandybot/handlers/procesar_correos.py' 'Sandy bot/sandybot/handlers/tarea_programada.py' 'Sandy bot/sandybot/handlers/reenviar_aviso.py'`
- `pytest tests/test_procesar_correos.py tests/test_tarea_programada.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e646b5f88330961b7044843c4473