### PR TITLE
Validación adicional de fecha en informe SLA

### DIFF
--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -218,6 +218,12 @@ def _generar_documento_sla(
         fecha = pd.to_datetime(reclamos_df.iloc[0].get("Fecha"))
     except Exception:
         fecha = pd.Timestamp.today()
+
+    # Validación de la fecha obtenida
+    if pd.isna(fecha) or not hasattr(fecha, "strftime"):
+        logger.warning("Fecha de reclamo inválida: %s. Se usa la fecha actual.", fecha)
+        fecha = pd.Timestamp.today()
+
     mes = fecha.strftime("%B")
     anio = fecha.strftime("%Y")
 


### PR DESCRIPTION
## Resumen
- controlar valores nulos o sin strftime al cargar la fecha

## Testing
- `pytest -q` *(falla una prueba)*

------
https://chatgpt.com/codex/tasks/task_e_6849e6826b648330967cdc79941de2f7