### PR TITLE
Actualizar documentación de informe SLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,7 @@ pip install -r requirements.txt
 Este flujo genera un reporte basado en el documento `Template Informe SLA.docx`, ubicado por defecto en `C:\Metrotel\Sandy`. Para iniciarlo presioná **Informe de SLA** en el menú principal o ejecutá `/informe_sla`.
 Al activarse se usa la plantilla indicada por `SLA_TEMPLATE_PATH`. Si no se define, se toma `C:\Metrotel\Sandy\Template Informe SLA.docx`.
 El archivo debe existir en formato `.docx`.
-El bot solicitará primero el Excel de **reclamos** y luego el de **servicios**. Estos archivos se pueden enviar por separado.
-Una vez que el bot recibe ambos aparecerá el botón **Procesar**, que genera el informe utilizando la plantilla configurada en `SLA_TEMPLATE_PATH`.
-Después de procesar los Excel deberás escribir los textos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora** que se insertarán en el documento.
+El bot solicitará primero el Excel de **reclamos** y luego el de **servicios**. Estos archivos se pueden enviar por separado. Una vez que el bot recibe ambos aparecerá el botón **Procesar**, que genera el informe utilizando la plantilla configurada en `SLA_TEMPLATE_PATH`. El documento se crea automáticamente con los campos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora** en blanco.
 
 ```env
 SLA_TEMPLATE_PATH=/ruta/personalizada/Template SLA.docx

--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -180,8 +180,7 @@ adicional.
    - Genera un resumen de nivel de servicio usando `Template Informe SLA.docx`
    - Podés iniciarlo desde el botón **Informe de SLA** o con `/informe_sla`
    - Solicita los Excel de reclamos y servicios, que pueden enviarse por separado
-   - Una vez cargados los dos archivos aparece el botón **Procesar**, que genera el informe según `SLA_TEMPLATE_PATH`
-   - Luego pide los textos de eventos, conclusión y mejora
+   - Una vez cargados los dos archivos aparece el botón **Procesar**, que genera el informe según `SLA_TEMPLATE_PATH` con los campos de eventos, conclusión y mejora en blanco
 
 
 8. Consultas generales
@@ -194,8 +193,7 @@ adicional.
 Esta opcion genera un documento de nivel de servicio basado en `Template Informe SLA.docx`.
 Podes iniciarla desde el boton **Informe de SLA** o con el comando `/informe_sla`.
 El bot pedirá primero el Excel de **reclamos** y luego el de **servicios**. Podés enviarlos por separado sin importar el orden.
-Cuando ambos estén disponibles aparecerá un botón **Procesar**, que genera el informe usando la plantilla definida en `SLA_TEMPLATE_PATH`.
-Después solicitará escribir los textos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora**.
+Cuando ambos estén disponibles aparecerá un botón **Procesar**, que genera el informe usando la plantilla definida en `SLA_TEMPLATE_PATH`. El documento se crea automáticamente con los textos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora** en blanco.
 
 
 ```env


### PR DESCRIPTION
## Resumen
- detallar en README principal que el informe se genera con los campos vacíos
- aclarar lo mismo en la guía de `Sandy bot`

## Testing
- `bash setup_env.sh`
- `pytest -q` *(falla: TypeError en `test_procesar_informe_sla`)*

------
https://chatgpt.com/codex/tasks/task_e_6849e69425d883309bb8a47d817704b1