### PR TITLE
Permite modificar la plantilla del informe SLA

### DIFF
--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -13,7 +13,11 @@ from .voice import voice_handler
 from .ingresos import iniciar_verificacion_ingresos, procesar_ingresos
 from .registro_ingresos import iniciar_registro_ingresos, guardar_registro
 from .repetitividad import procesar_repetitividad
-from .informe_sla import iniciar_informe_sla, procesar_informe_sla
+from .informe_sla import (
+    iniciar_informe_sla,
+    procesar_informe_sla,
+    actualizar_plantilla_sla,
+)
 from .comparador import iniciar_comparador, recibir_tracking, procesar_comparacion
 from .cargar_tracking import iniciar_carga_tracking, guardar_tracking_servicio
 from .descargar_tracking import iniciar_descarga_tracking, enviar_tracking_servicio
@@ -70,6 +74,7 @@ __all__ = [
     "procesar_incidencias",
     "iniciar_informe_sla",
     "procesar_informe_sla",
+    "actualizar_plantilla_sla",
     "agregar_destinatario",
     "eliminar_destinatario",
     "listar_destinatarios",

--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -135,6 +135,11 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         registrar_conversacion(user_id, "sla_procesar", "Procesar informe", "callback")
         await procesar_informe_sla(update, context)
 
+    elif data == "sla_cambiar_plantilla":
+        context.user_data["cambiar_plantilla"] = True
+        registrar_conversacion(user_id, "sla_cambiar_plantilla", "Solicitar plantilla", "callback")
+        await query.edit_message_text("Adjuntá la nueva plantilla .docx")
+
     # ─────────────────────────────── OTROS ─────────────────────────────────
     elif data == "otro":
         UserState.set_mode(user_id, "sandy")


### PR DESCRIPTION
## Summary
- agrega botón **Actualizar plantilla** al flujo de SLA
- permite subir un `.docx` para cambiar la plantilla configurada
- registra la acción y actualiza el archivo indicado en `config.SLA_PLANTILLA_PATH`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f04f1fb08330b50b20afe071196b