### PR TITLE
Add PDF export to SLA generator

### DIFF
--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -181,6 +181,7 @@ adicional.
    - Podés iniciarlo desde el botón **Informe de SLA** o con `/informe_sla`
    - Solicita los Excel de reclamos y servicios, que pueden enviarse por separado
    - Una vez cargados los dos archivos aparece el botón **Procesar**, que genera el informe según `SLA_TEMPLATE_PATH` con los campos de eventos, conclusión y mejora en blanco
+   - En Windows podés definir `exportar_pdf=True` para obtener también la versión PDF si `pywin32` está disponible
 
 
 8. Consultas generales
@@ -194,6 +195,7 @@ Esta opcion genera un documento de nivel de servicio basado en `Template Informe
 Podes iniciarla desde el boton **Informe de SLA** o con el comando `/informe_sla`.
 El bot pedirá primero el Excel de **reclamos** y luego el de **servicios**. Podés enviarlos por separado sin importar el orden.
 Cuando ambos estén disponibles aparecerá un botón **Procesar**, que genera el informe usando la plantilla definida en `SLA_TEMPLATE_PATH`. El documento se crea automáticamente con los textos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora** en blanco.
+Si la función `_generar_documento_sla` se llama con `exportar_pdf=True` y el bot se ejecuta en Windows, también se genera un PDF empleando `win32com`.
 
 
 ```env

--- a/Sandy bot/requirements.txt
+++ b/Sandy bot/requirements.txt
@@ -9,7 +9,7 @@ notion-client>=1.0.0
 fuzzywuzzy>=0.18.0
 python-Levenshtein>=0.12.0
 extract-msg==0.23.1
-pywin32>=300; sys_platform == 'win32'
+pywin32>=300; sys_platform == 'win32'  # necesario para exportar a PDF
 jsonschema>=4.0.0
 SQLAlchemy>=1.4
 textract==1.6.3  # opcional para archivos .doc

--- a/tests/test_informe_sla.py
+++ b/tests/test_informe_sla.py
@@ -3,6 +3,7 @@ import importlib
 import asyncio
 from types import ModuleType, SimpleNamespace
 from pathlib import Path
+import os
 from sqlalchemy.orm import sessionmaker
 import tempfile
 import os
@@ -252,5 +253,6 @@ def test_generar_sin_fecha(tmp_path):
     reclamos.to_excel(r_path, index=False)
     servicios.to_excel(s_path, index=False)
 
-    ruta = informe._generar_documento_sla(str(r_path), str(s_path))
+    ruta = informe._generar_documento_sla(str(r_path), str(s_path), exportar_pdf=True)
     assert Path(ruta).exists()
+    assert ruta.endswith(".pdf") if os.name == "nt" else ruta.endswith(".docx")


### PR DESCRIPTION
## Summary
- support optional PDF export on Windows when generating SLA documents
- document new capability and update requirements
- improve handler to tolerate missing Telegram classes during tests
- test PDF export argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f052f5448330ab658adcfb52b430