### PR TITLE
Actualiza documentación de informes y pruebas

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,27 @@ EMAIL_FROM=tu_correo@gmail.com
 ```
 Nota: si copiás la contraseña de aplicación de Gmail, asegurate de quitar los espacios que se muestran por legibilidad.
 
+Para la suite de pruebas se pueden definir variables mínimas en un `.env` o en la consola antes de ejecutar `pytest`:
+
+```bash
+export TELEGRAM_TOKEN=dummy
+export OPENAI_API_KEY=dummy
+export NOTION_TOKEN=dummy
+export NOTION_DATABASE_ID=dummy
+export DB_USER=postgres
+export DB_PASSWORD=postgres
+```
+
 ## Plantilla de informes de repetitividad
 
 El documento base para generar los reportes de repetitividad se indica
 mediante la variable de entorno `PLANTILLA_PATH`. Si no se define, el
 código toma la ruta por defecto `C:\Metrotel\Sandy\plantilla_informe.docx`
 tal como se especifica en `config.py`.
+El título del documento se ajusta al mes actual en español y, si la plantilla
+no cuenta con el estilo `Title`, se utiliza `Heading 1` como alternativa.
+En el menú del bot existe un botón para reemplazar la plantilla de
+repetitividad y otro que permite exportar el informe final a PDF.
 
 ## Plantilla del informe de SLA
 

--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -194,6 +194,8 @@ Esta opcion genera un documento de nivel de servicio basado en `Template Informe
 Podes iniciarla desde el boton **Informe de SLA** o con el comando `/informe_sla`.
 El bot pedirá primero el Excel de **reclamos** y luego el de **servicios**. Podés enviarlos por separado sin importar el orden.
 Cuando ambos estén disponibles aparecerá un botón **Procesar**, que genera el informe usando la plantilla definida en `SLA_TEMPLATE_PATH`. El documento se crea automáticamente con los textos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora** en blanco.
+El título del informe se adapta al mes correspondiente en español. Si el documento de plantilla no incluye el estilo `Title`, el bot emplea `Heading 1` como respaldo.
+Además se agregó un botón para reemplazar la plantilla actual y otro para exportar el resultado directamente a PDF.
 
 
 ```env
@@ -206,6 +208,17 @@ Si la ruta no existe se mostrará el mensaje "Plantilla de SLA no encontrada" y 
 
 Para ejecutar la suite de tests primero corré `setup_env.sh`.
 Ese script instala las dependencias en `.venv` y configura `PYTHONPATH`.
+Antes de correr las pruebas definí algunas variables de entorno mínimas:
+
+```bash
+export TELEGRAM_TOKEN=dummy
+export OPENAI_API_KEY=dummy
+export NOTION_TOKEN=dummy
+export NOTION_DATABASE_ID=dummy
+export DB_USER=postgres
+export DB_PASSWORD=postgres
+```
+
 Luego podés lanzar `pytest` normalmente.
 
 ```bash


### PR DESCRIPTION
## Summary
- amplía README con variables mínimas para las pruebas
- explica ajustes automáticos del título y nuevas opciones en los informes
- actualiza README de `Sandy bot` con las mismas aclaraciones

## Testing
- `./setup_env.sh`
- `source .venv/bin/activate && pytest -q` *(falla: TypeError en test_informe_sla)*

------
https://chatgpt.com/codex/tasks/task_e_6849f05b3ab48330a957a4cc0072290f