### PR TITLE
Agrega encabezados y corrige test de SLA

### DIFF
--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -1,3 +1,6 @@
+# + Nombre de archivo: informe_sla.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/informe_sla.py
+# User-provided custom instructions
 """Handler para generar informes de SLA."""
 
 from __future__ import annotations

--- a/tests/test_informe_sla.py
+++ b/tests/test_informe_sla.py
@@ -1,6 +1,22 @@
+# + Nombre de archivo: test_informe_sla.py
+# + Ubicación de archivo: tests/test_informe_sla.py
+# User-provided custom instructions
 """Handler para generar informes de SLA."""
 
 from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+pkg = "sandybot.handlers"
+if pkg not in sys.modules:
+    handlers_pkg = ModuleType(pkg)
+    handlers_pkg.__path__ = [str(ROOT_DIR / "Sandy bot" / "sandybot" / "handlers")]
+    sys.modules[pkg] = handlers_pkg
+sys.path.append(str(ROOT_DIR / "Sandy bot"))
+__package__ = pkg
 
 import logging
 import os


### PR DESCRIPTION
## Resumen
- se añaden las líneas de identificación en `informe_sla.py` y `test_informe_sla.py`
- se ajusta `test_informe_sla.py` para poder importar módulos del paquete sin ejecutar `__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a00be899c8330a1d4a89c7a64d71a