### PR TITLE
Añade pruebas async de informe SLA

### DIFF
--- a/tests/test_informe_sla.py
+++ b/tests/test_informe_sla.py
@@ -1,304 +1,156 @@
-"""Handler para generar informes de SLA."""
-
-from __future__ import annotations
-
-import logging
+# + Nombre de archivo: test_informe_sla.py
+# + Ubicacion de archivo: tests/test_informe_sla.py
+# User-provided custom instructions
+import sys
+import importlib
+import asyncio
 import os
-import tempfile
-import locale
-from types import SimpleNamespace
-from typing import Optional
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
 import pandas as pd
 from docx import Document
-from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
-from telegram.ext import ContextTypes
 
-# ► Exportar a PDF (solo funciona en entornos donde esté disponible)
-try:  # pragma: no cover
-    import win32com.client as win32  # type: ignore
-except Exception:  # pragma: no cover
-    win32 = None
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
-from sandybot.config import config
-from ..utils import obtener_mensaje
-from .estado import UserState
-from ..registrador import responder_registrando, registrar_conversacion
+from tests.telegram_stub import Message, Update
 
-# Plantilla predeterminada
-RUTA_PLANTILLA = config.SLA_PLANTILLA_PATH
+# Stub de dotenv requerido por config
+dotenv_stub = ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault("dotenv", dotenv_stub)
 
-logger = logging.getLogger(__name__)
+# Variables de entorno minimas
+for var in [
+    "TELEGRAM_TOKEN",
+    "OPENAI_API_KEY",
+    "NOTION_TOKEN",
+    "NOTION_DATABASE_ID",
+    "DB_USER",
+    "DB_PASSWORD",
+    "SLACK_WEBHOOK_URL",
+    "SUPERVISOR_DB_ID",
+]:
+    os.environ.setdefault(var, "x")
 
 
-# ─────────────────────────────── INICIO ──────────────────────────────
-async def iniciar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Coloca al usuario en modo *informe_sla* y solicita los dos Excel."""
-    mensaje = obtener_mensaje(update)
-    if not mensaje:
-        logger.warning("No se recibió mensaje en iniciar_informe_sla")
-        return
+captura = {}
+registrador_stub = ModuleType("sandybot.registrador")
+async def responder_registrando(*args, **kwargs):
+    captura["texto"] = args[3]
+    captura["reply_markup"] = kwargs.get("reply_markup")
+registrador_stub.responder_registrando = responder_registrando
+registrador_stub.registrar_conversacion = lambda *a, **k: None
+sys.modules["sandybot.registrador"] = registrador_stub
 
-    user_id = update.effective_user.id
-    UserState.set_mode(user_id, "informe_sla")
-    context.user_data.clear()
-    context.user_data["archivos"] = [None, None]  # [reclamos, servicios]
 
-    # Botón para actualizar plantilla
-    try:
-        kb = InlineKeyboardMarkup(
-            [[InlineKeyboardButton("Actualizar plantilla", callback_data="sla_cambiar_plantilla")]]
-        )
-    except Exception:  # fallback en tests
-        btn = SimpleNamespace(text="Actualizar plantilla", callback_data="sla_cambiar_plantilla")
-        kb = SimpleNamespace(inline_keyboard=[[btn]])
+def _importar(tmp_path: Path):
+    os.environ["SLA_TEMPLATE_PATH"] = str(tmp_path / "plantilla.docx")
+    plantilla = Path(os.environ["SLA_TEMPLATE_PATH"])
+    Document().save(plantilla)
 
-    await responder_registrando(
-        mensaje,
-        user_id,
-        "informe_sla",
-        "Enviá el Excel de **reclamos** y luego el de **servicios** para generar el informe.",
-        "informe_sla",
-        reply_markup=kb,
+    # Clases simples para capturar los callbacks
+    class _Btn:
+        def __init__(self, text, callback_data=None):
+            self.text = text
+            self.callback_data = callback_data
+
+    class _Markup:
+        def __init__(self, keyboard):
+            self.inline_keyboard = keyboard
+
+    sys.modules["telegram"].InlineKeyboardButton = _Btn
+    sys.modules["telegram"].InlineKeyboardMarkup = _Markup
+    sys.modules["sandybot.registrador"] = registrador_stub
+
+    pkg = "sandybot.handlers"
+    if pkg not in sys.modules:
+        handlers_pkg = ModuleType(pkg)
+        handlers_pkg.__path__ = [str(ROOT_DIR / "Sandy bot" / "sandybot" / "handlers")]
+        sys.modules[pkg] = handlers_pkg
+    mod_name = f"{pkg}.informe_sla"
+    spec = importlib.util.spec_from_file_location(
+        mod_name,
+        ROOT_DIR / "Sandy bot" / "sandybot" / "handlers" / "informe_sla.py",
     )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    mod.RUTA_PLANTILLA = str(plantilla)
+    return mod
 
 
-# ────────────────────────── PROCESO COMPLETO ─────────────────────────
-async def procesar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Gestiona la carga de Excel, generación y envío del informe SLA."""
-    mensaje = obtener_mensaje(update)
-    if not mensaje:
-        logger.warning("No se recibió mensaje en procesar_informe_sla")
-        return
+class ExcelDoc:
+    def __init__(self, file_name: str, path: Path):
+        self.file_name = file_name
+        self._path = path
 
-    user_id = update.effective_user.id
-    archivos = context.user_data.setdefault("archivos", [None, None])
-
-    # 1) ── Callback para cambiar plantilla ───────────────────────────
-    if update.callback_query and update.callback_query.data == "sla_cambiar_plantilla":
-        context.user_data["cambiar_plantilla"] = True
-        await update.callback_query.message.reply_text("Adjuntá la nueva plantilla .docx.")
-        return
-
-    # 2) ── Guardar la nueva plantilla, si se solicitó ────────────────
-    if context.user_data.get("cambiar_plantilla"):
-        if getattr(mensaje, "document", None):
-            await _actualizar_plantilla_sla(mensaje, context)
-        else:
-            await responder_registrando(
-                mensaje,
-                user_id,
-                getattr(mensaje, "text", ""),
-                "Adjuntá el archivo .docx para actualizar la plantilla.",
-                "informe_sla",
-            )
-        return
-
-    # 3) ── Callback «Procesar informe» ───────────────────────────────
-    if update.callback_query and update.callback_query.data == "sla_procesar":
-        try:
-            ruta_final = _generar_documento_sla(*archivos)
-            with open(ruta_final, "rb") as f:
-                await update.callback_query.message.reply_document(f, filename=os.path.basename(ruta_final))
-            registrar_conversacion(
-                user_id, "informe_sla", f"Documento {os.path.basename(ruta_final)} enviado", "informe_sla"
-            )
-        except Exception as e:  # pragma: no cover
-            logger.error("Error generando informe SLA: %s", e)
-            await update.callback_query.message.reply_text("💥 Algo falló generando el informe de SLA.")
-        finally:
-            for p in archivos:
-                try:
-                    os.remove(p)
-                except OSError:
-                    pass
-            if "ruta_final" in locals() and os.path.exists(ruta_final):
-                os.remove(ruta_final)
-            context.user_data.clear()
-            UserState.set_mode(user_id, "")
-        return
-
-    # 4) ── Recepción de archivos Excel ───────────────────────────────
-    docs = [d for d in (getattr(mensaje, "document", None), *getattr(mensaje, "documents", [])) if d]
-    if docs:
-        for doc in docs:
-            f = await doc.get_file()
-            with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as tmp:
-                await f.download_to_drive(tmp.name)
-                nombre = doc.file_name.lower()
-                if "recl" in nombre and archivos[0] is None:
-                    archivos[0] = tmp.name
-                elif "serv" in nombre and archivos[1] is None:
-                    archivos[1] = tmp.name
-                elif archivos[0] is None:
-                    archivos[0] = tmp.name
-                else:
-                    archivos[1] = tmp.name
-
-        if None in archivos:
-            falta = "reclamos" if archivos[0] is None else "servicios"
-            await responder_registrando(
-                mensaje, user_id, docs[-1].file_name,
-                f"Archivo guardado. Falta el Excel de {falta}.", "informe_sla",
-            )
-            return
-
-        # Mostrar botón Procesar
-        try:
-            kb = InlineKeyboardMarkup(
-                [[InlineKeyboardButton("Procesar informe 🚀", callback_data="sla_procesar")]]
-            )
-        except Exception:  # fallback stubs
-            btn = SimpleNamespace(text="Procesar informe 🚀", callback_data="sla_procesar")
-            kb = SimpleNamespace(inline_keyboard=[[btn]])
-
-        await responder_registrando(
-            mensaje, user_id, docs[-1].file_name,
-            "Archivos cargados. Presioná *Procesar informe*.", "informe_sla", reply_markup=kb,
-        )
-        return
-
-    # 5) ── Ningún adjunto ni callback reconocido ─────────────────────
-    await responder_registrando(
-        mensaje, user_id, getattr(mensaje, "text", ""),
-        "Adjuntá los archivos de reclamos y servicios para comenzar.", "informe_sla",
-    )
+    async def get_file(self):
+        class F:
+            async def download_to_drive(_, dest):
+                Path(dest).write_bytes(Path(self._path).read_bytes())
+        return F()
 
 
-# ──────────────────── ACTUALIZAR PLANTILLA SLA ───────────────────────
-async def _actualizar_plantilla_sla(mensaje, context):
-    user_id = mensaje.from_user.id
-    archivo = mensaje.document
-    if not archivo.file_name.lower().endswith(".docx"):
-        await responder_registrando(mensaje, user_id, archivo.file_name, "El archivo debe ser .docx.", "informe_sla")
-        return
-    try:
-        f = await archivo.get_file()
-        os.makedirs(os.path.dirname(RUTA_PLANTILLA), exist_ok=True)
-        await f.download_to_drive(RUTA_PLANTILLA)
-        texto = "Plantilla de SLA actualizada."
-        context.user_data.pop("cambiar_plantilla", None)
-    except Exception as exc:  # pragma: no cover
-        logger.error("Error guardando plantilla SLA: %s", exc)
-        texto = "No se pudo guardar la plantilla."
+async def _flujo_completo(tmp_path):
+    mod = _importar(tmp_path)
+    ctx = SimpleNamespace(user_data={})
+    msg = Message("/sla")
+    update = Update(message=msg)
+    await mod.iniciar_informe_sla(update, ctx)
 
-    await responder_registrando(mensaje, user_id, archivo.file_name, texto, "informe_sla")
+    reclamos = pd.DataFrame({"Servicio": ["Srv"], "Fecha": ["2024-01-01"]})
+    servicios = pd.DataFrame({"Servicio": ["Srv"]})
+    recl_path = tmp_path / "recl.xlsx"
+    serv_path = tmp_path / "serv.xlsx"
+    reclamos.to_excel(recl_path, index=False)
+    servicios.to_excel(serv_path, index=False)
+
+    doc_recl = ExcelDoc("reclamos.xlsx", recl_path)
+    msg2 = Message(document=doc_recl)
+    await mod.procesar_informe_sla(Update(message=msg2), ctx)
+    assert "Falta el Excel de servicios" in captura["texto"]
+
+    captura.clear()
+    doc_serv = ExcelDoc("servicios.xlsx", serv_path)
+    msg3 = Message(document=doc_serv)
+    await mod.procesar_informe_sla(Update(message=msg3), ctx)
+    boton = captura["reply_markup"].inline_keyboard[0][0]
+    assert boton.callback_data == "sla_procesar"
+
+    captura.clear()
+    cb = SimpleNamespace(data="sla_procesar", message=msg3)
+    await mod.procesar_informe_sla(Update(callback_query=cb), ctx)
+    enviado = msg3.documento
+    assert enviado and not os.path.exists(enviado)
+    assert ctx.user_data == {}
 
 
-# ─────────────────── FUNCIÓN GENERADORA DE WORD ──────────────────────
-def _generar_documento_sla(
-    reclamos_xlsx: str,
-    servicios_xlsx: str,
-    eventos: Optional[str] = "",
-    conclusion: Optional[str] = "",
-    propuesta: Optional[str] = "",
-    *,
-    exportar_pdf: bool = False,
-) -> str:
-    """Genera el documento SLA; si `exportar_pdf` es True intenta generar PDF."""
-    reclamos_df = pd.read_excel(reclamos_xlsx)
-    servicios_df = pd.read_excel(servicios_xlsx)
+async def _cambiar_plantilla(tmp_path):
+    mod = _importar(tmp_path)
+    ctx = SimpleNamespace(user_data={})
+    msg = Message("/sla")
+    await mod.iniciar_informe_sla(Update(message=msg), ctx)
 
-    columnas_extra = [c for c in ("SLA Entregado", "Dirección", "Horas Netas Reclamo") if c in servicios_df]
+    captura.clear()
+    cb = SimpleNamespace(data="sla_cambiar_plantilla", message=msg)
+    await mod.procesar_informe_sla(Update(callback_query=cb), ctx)
+    assert ctx.user_data.get("cambiar_plantilla") is True
 
-    # Normaliza nombres
-    if "Servicio" not in reclamos_df.columns:
-        reclamos_df.rename(columns={reclamos_df.columns[0]: "Servicio"}, inplace=True)
-    if "Servicio" not in servicios_df.columns:
-        servicios_df.rename(columns={servicios_df.columns[0]: "Servicio"}, inplace=True)
+    nueva = tmp_path / "nueva.docx"
+    Document().save(nueva)
+    doc = ExcelDoc("nueva.docx", nueva)
+    msg2 = Message(document=doc)
+    await mod.procesar_informe_sla(Update(message=msg2), ctx)
+    assert "actualizada" in captura["texto"].lower()
+    assert Path(mod.RUTA_PLANTILLA).exists()
+    assert "cambiar_plantilla" not in ctx.user_data
 
-    # Fecha para título
-    try:
-        fecha = pd.to_datetime(reclamos_df.iloc[0].get("Fecha"))
-        if pd.isna(fecha):
-            raise ValueError
-    except Exception:
-        fecha = pd.Timestamp.today()
 
-    # Locale español (ignora errores si no está instalado)
-    for loc in ("es_ES.UTF-8", "es_ES", "es_AR.UTF-8", "es_AR"):
-        try:
-            locale.setlocale(locale.LC_TIME, loc)
-            break
-        except locale.Error:
-            continue
+def test_flujo_completo(tmp_path):
+    asyncio.run(_flujo_completo(tmp_path))
 
-    mes, anio = fecha.strftime("%B").upper(), fecha.strftime("%Y")
 
-    # Conteo de reclamos
-    resumen = reclamos_df.groupby("Servicio").size().reset_index(name="Reclamos")
-    df = servicios_df.merge(resumen, on="Servicio", how="left")
-    df["Reclamos"] = df["Reclamos"].fillna(0).astype(int)
-
-    # Documento base
-    if not (RUTA_PLANTILLA and os.path.exists(RUTA_PLANTILLA)):
-        raise ValueError(f"Plantilla de SLA no encontrada: {RUTA_PLANTILLA}")
-    doc = Document(RUTA_PLANTILLA)
-
-    try:
-        doc.add_heading(f"Informe SLA {mes} {anio}", level=0)
-    except KeyError:
-        doc.add_heading(f"Informe SLA {mes} {anio}", level=1)
-
-    # Tabla resumen
-    headers = ["Servicio", *columnas_extra, "Reclamos"]
-    tbl = doc.add_table(rows=1, cols=len(headers), style="Table Grid")
-    for i, h in enumerate(headers):
-        tbl.rows[0].cells[i].text = h
-
-    for _, fila in df.iteritems():
-        cells = tbl.add_row().cells
-        for i, h in enumerate(headers):
-            cells[i].text = str(fila.get(h, ""))
-
-    # Etiquetas dinámicas
-    etiquetas = {
-        "Eventos sucedidos de mayor impacto en SLA:": eventos,
-        "Conclusión:": conclusion,
-        "Propuesta de mejora:": propuesta,
-    }
-    encontrados = set()
-    for p in doc.paragraphs:
-        for etq, cont in etiquetas.items():
-            if p.text.strip().startswith(etq):
-                p.text = f"{etq} {cont}"
-                encontrados.add(etq)
-                break
-    for etq, cont in etiquetas.items():
-        if etq not in encontrados and cont:
-            doc.add_paragraph(f"{etq} {cont}")
-
-    # Guardar DOCX
-    fd, ruta_docx = tempfile.mkstemp(suffix=".docx")
-    os.close(fd)
-    doc.save(ruta_docx)
-
-    # Exportar PDF (opcional)
-    if exportar_pdf:
-        pdf_path = os.path.splitext(ruta_docx)[0] + ".pdf"
-        convertido = False
-
-        if win32 and os.name == "nt":
-            try:
-                word = win32.Dispatch("Word.Application")
-                word_doc = word.Documents.Open(ruta_docx)
-                word_doc.SaveAs(pdf_path, FileFormat=17)
-                word_doc.Close()
-                word.Quit()
-                convertido = True
-            except Exception:
-                logger.warning("Fallo exportando PDF con win32")
-
-        if not convertido:
-            try:
-                from docx2pdf import convert  # type: ignore
-                convert(ruta_docx, pdf_path)
-                convertido = True
-            except Exception:
-                logger.warning("Fallo exportando PDF con docx2pdf")
-
-        if convertido:
-            os.remove(ruta_docx)
-            return pdf_path
-
-    return ruta_docx
+def test_cambiar_plantilla(tmp_path):
+    asyncio.run(_cambiar_plantilla(tmp_path))


### PR DESCRIPTION
## Summary
- reemplaza contenido de `tests/test_informe_sla.py`
- implementa pruebas asíncronas del flujo de generación y actualización de plantilla de SLA

## Testing
- `pytest tests/test_informe_sla.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a020da8148330886686e24590e4ff