### PR TITLE
Añadir exportación a PDF en informes SLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Este repositorio contiene el proyecto SandyBot. Para ejecutarlo se requiere
 instalar las dependencias listadas en `Sandy bot/requirements.txt`. Se recomienda usar
 la versión `openai>=1.0.0` para garantizar compatibilidad con la nueva
 API utilizada en `sandybot`. Es obligatorio instalar `extract-msg` para leer los
-adjuntos `.msg` y opcionalmente `pywin32`, que permite insertar la firma,
-generar un `.MSG` real desde Outlook y exportar informes a PDF. Desde esta versión el bot también acepta
+adjuntos `.msg` y opcionalmente `pywin32` en Windows o `docx2pdf` en otros sistemas.
+Estas librerías permiten insertar la firma, generar un `.MSG` real desde Outlook y exportar informes a PDF. Desde esta versión el bot también acepta
 mensajes de voz, los descarga y los transcribe automáticamente utilizando la API
 de OpenAI.
 
@@ -296,7 +296,7 @@ pip install -r requirements.txt
 Este flujo genera un reporte basado en el documento `Template Informe SLA.docx`, ubicado por defecto en `C:\Metrotel\Sandy`. Para iniciarlo presioná **Informe de SLA** en el menú principal o ejecutá `/informe_sla`.
 Al activarse se usa la plantilla indicada por `SLA_TEMPLATE_PATH`. Si no se define, se toma `C:\Metrotel\Sandy\Template Informe SLA.docx`.
 El archivo debe existir en formato `.docx`.
-El bot solicitará primero el Excel de **reclamos** y luego el de **servicios**. Estos archivos se pueden enviar por separado. Una vez que el bot recibe ambos aparecerá el botón **Procesar**, que genera el informe utilizando la plantilla configurada en `SLA_TEMPLATE_PATH`. El documento se crea automáticamente con los campos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora** en blanco. Si ejecutás la función `_generar_documento_sla` con `exportar_pdf=True` y contás con `pywin32` en Windows, también se guardará una versión PDF.
+El bot solicitará primero el Excel de **reclamos** y luego el de **servicios**. Estos archivos se pueden enviar por separado. Una vez que el bot recibe ambos aparecen los botones **Procesar** y **Exportar a PDF**. El informe utiliza la plantilla configurada en `SLA_TEMPLATE_PATH` y deja en blanco los campos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora**. Si ejecutás `_generar_documento_sla(exportar_pdf=True)` con `pywin32` en Windows o con `docx2pdf` en otros sistemas, se guardará también la versión PDF.
 
 ```env
 SLA_TEMPLATE_PATH=/ruta/personalizada/Template SLA.docx
@@ -307,9 +307,9 @@ Si la ruta no es válida se mostrará el error "Plantilla de SLA no encontrada" 
 ### Ejemplo completo del flujo
 
 1. Enviá el Excel con los **reclamos** y luego el de **servicios**.
-2. Una vez recibidos ambos, el bot muestra el botón **Procesar**.
-3. Al presionarlo se genera el documento en una ruta temporal con un nombre aleatorio.
-   Si se llama a `_generar_documento_sla(exportar_pdf=True)` en Windows, también se guarda la versión PDF.
+2. Una vez recibidos ambos, el bot muestra los botones **Procesar** y **Exportar a PDF**.
+3. Al presionar alguna opción se genera el documento en una ruta temporal con un nombre aleatorio.
+   Si se llama a `_generar_documento_sla(exportar_pdf=True)` con `pywin32` en Windows o con `docx2pdf` en otros sistemas, también se guarda la versión PDF.
 4. Finalmente el archivo se envía por Telegram y se elimina automáticamente del sistema para evitar residuos.
 5. En cualquier momento se puede usar el botón **Actualizar plantilla** para cargar una nueva base en formato `.docx`.
 

--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -180,8 +180,8 @@ adicional.
    - Genera un resumen de nivel de servicio usando `Template Informe SLA.docx`
    - Podés iniciarlo desde el botón **Informe de SLA** o con `/informe_sla`
    - Solicita los Excel de reclamos y servicios, que pueden enviarse por separado
-   - Una vez cargados los dos archivos aparece el botón **Procesar**, que genera el informe según `SLA_TEMPLATE_PATH` con los campos de eventos, conclusión y mejora en blanco
-   - En Windows podés definir `exportar_pdf=True` para obtener también la versión PDF si tenés instalada la librería `pywin32`
+   - Una vez cargados los dos archivos aparecen los botones **Procesar** y **Exportar a PDF** para generar el informe según `SLA_TEMPLATE_PATH`
+   - En Windows podés definir `exportar_pdf=True` si contás con `pywin32`. En otros sistemas necesitás la librería `docx2pdf` para crear la versión PDF
 
 
 8. Consultas generales
@@ -193,10 +193,10 @@ adicional.
 
 Esta opcion genera un documento de nivel de servicio basado en `Template Informe SLA.docx`.
 Podes iniciarla desde el boton **Informe de SLA** o con el comando `/informe_sla`.
-El bot pedirá primero el Excel de **reclamos** y luego el de **servicios**. Podés enviarlos por separado sin importar el orden.
-Cuando ambos estén disponibles aparecerá un botón **Procesar**, que genera el informe usando la plantilla definida en `SLA_TEMPLATE_PATH`. El documento se crea automáticamente con los textos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora** en blanco.
-El título del informe se adapta al mes correspondiente en español. Si el documento de plantilla no incluye el estilo `Title`, el bot emplea `Heading 1` como respaldo.
-Además se agregó un botón para reemplazar la plantilla actual y otro para exportar el resultado directamente a PDF. Para que la conversión funcione tenés que ejecutar `_generar_documento_sla(exportar_pdf=True)` en Windows y contar con `pywin32` instalado.
+El bot pedirá primero el Excel de **reclamos** y luego el de **servicios**, que se pueden enviar por separado.
+Cuando ambos estén disponibles aparecerán los botones **Procesar** y **Exportar a PDF**. El informe usa la plantilla definida en `SLA_TEMPLATE_PATH` y deja vacíos los textos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora**.
+El título del informe se adapta al mes correspondiente en español. Si la plantilla no incluye el estilo `Title`, el bot emplea `Heading 1` como respaldo.
+También existe un botón para reemplazar la plantilla y otro para obtener el PDF. Para generar esta versión se ejecuta `_generar_documento_sla(exportar_pdf=True)` con `pywin32` en Windows o con `docx2pdf` en otros sistemas.
 
 
 
@@ -209,9 +209,9 @@ Si la ruta no existe se mostrará el mensaje "Plantilla de SLA no encontrada" y 
 ### Ejemplo completo del flujo
 
 1. Enviá primero el Excel con los **reclamos** y después el de **servicios**.
-2. Tras recibir ambos archivos aparece el botón **Procesar**.
-3. Al usarlo se produce un archivo con nombre aleatorio en la carpeta temporal.
-   Si se incluye `exportar_pdf=True` y el bot corre en Windows, también se crea la versión PDF.
+2. Tras recibir ambos archivos aparecen los botones **Procesar** y **Exportar a PDF**.
+3. Al usar cualquiera de ellos se genera un archivo con nombre aleatorio en la carpeta temporal.
+   Si se incluye `exportar_pdf=True` con `pywin32` en Windows o con `docx2pdf` en otros sistemas, también se crea la versión PDF.
 4. El documento (DOCX o PDF) se envía por Telegram y luego se elimina de manera automática.
 5. Podés actualizar la plantilla en cualquier momento mediante el botón **Actualizar plantilla**.
 

--- a/Sandy bot/requirements.txt
+++ b/Sandy bot/requirements.txt
@@ -10,6 +10,7 @@ fuzzywuzzy>=0.18.0
 python-Levenshtein>=0.12.0
 extract-msg==0.23.1
 pywin32>=300; sys_platform == 'win32'  # necesario para exportar a PDF
+docx2pdf>=0.1.8
 jsonschema>=4.0.0
 SQLAlchemy>=1.4
 textract==1.6.3  # opcional para archivos .doc

--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -63,8 +63,13 @@ async def iniciar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYPE
 
 
 # ────────────────────────── FLUJO DE PROCESO ─────────────────────────
-async def procesar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Recibe dos Excel → botón “Procesar informe” → genera Word (y opcional PDF)."""
+async def procesar_informe_sla(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    exportar_pdf: bool = False,
+) -> None:
+    """Recibe los Excel, muestra opciones y genera el informe en Word o PDF."""
     mensaje = obtener_mensaje(update)
     if not mensaje:
         logger.warning("No se recibió mensaje en procesar_informe_sla")
@@ -94,15 +99,22 @@ async def procesar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYP
         return
 
     # ─── Callback «Procesar informe» ────────────────────────────────
-    if update.callback_query and update.callback_query.data == "sla_procesar":
+    if update.callback_query and update.callback_query.data in {"sla_procesar", "sla_pdf"}:
         reclamos_xlsx, servicios_xlsx = archivos
         try:
-            ruta_final = _generar_documento_sla(reclamos_xlsx, servicios_xlsx)
+            ruta_final = _generar_documento_sla(
+                reclamos_xlsx,
+                servicios_xlsx,
+                exportar_pdf=exportar_pdf or update.callback_query.data == "sla_pdf",
+            )
             with open(ruta_final, "rb") as f:
                 await update.callback_query.message.reply_document(f, filename=os.path.basename(ruta_final))
             os.remove(ruta_final)
             registrar_conversacion(
-                user_id, "informe_sla", f"Documento {os.path.basename(ruta_final)} enviado", "informe_sla"
+                user_id,
+                "informe_sla",
+                f"Documento {os.path.basename(ruta_final)} enviado",
+                "informe_sla",
             )
         except Exception as e:  # pragma: no cover
             logger.error("Error generando informe SLA: %s", e)
@@ -142,17 +154,19 @@ async def procesar_informe_sla(update: Update, context: ContextTypes.DEFAULT_TYP
             )
             return
 
-        # Ambos archivos listos → botón Procesar
+        # Ambos archivos listos → botones para procesar
         try:
-            boton = InlineKeyboardButton("Procesar informe 🚀", callback_data="sla_procesar")
-            keyboard = InlineKeyboardMarkup([[boton]])
+            procesar = InlineKeyboardButton("Procesar informe 🚀", callback_data="sla_procesar")
+            pdf = InlineKeyboardButton("Exportar a PDF", callback_data="sla_pdf")
+            keyboard = InlineKeyboardMarkup([[procesar, pdf]])
         except Exception:  # fallback para stubs
-            boton = SimpleNamespace(text="Procesar informe 🚀", callback_data="sla_procesar")
-            keyboard = SimpleNamespace(inline_keyboard=[[boton]])
+            procesar = SimpleNamespace(text="Procesar informe 🚀", callback_data="sla_procesar")
+            pdf = SimpleNamespace(text="Exportar a PDF", callback_data="sla_pdf")
+            keyboard = SimpleNamespace(inline_keyboard=[[procesar, pdf]])
 
         await responder_registrando(
             mensaje, user_id, docs[-1].file_name,
-            "Archivos cargados. Presioná *Procesar informe*.", "informe_sla",
+            "Archivos cargados. Elegí una opción.", "informe_sla",
             reply_markup=keyboard,
         )
         return

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -20,6 +20,7 @@ fi
 # Actualizar pip e instalar dependencias
 pip install --upgrade pip
 pip install --cache-dir "$PIP_CACHE_DIR" -r "Sandy bot/requirements.txt"
+pip install docx2pdf
 
 # Herramientas de pruebas
 pip install pytest pytest-cov


### PR DESCRIPTION
## Summary
- permitir que `procesar_informe_sla` reciba `exportar_pdf` y añadir botón `Exportar a PDF`
- instalar `docx2pdf` al preparar el entorno
- documentar el uso de `docx2pdf` como alternativa a `pywin32` en Linux/Mac

## Testing
- `./setup_env.sh`
- `.venv/bin/pytest -q` *(falla: ImportError en tests/test_informe_sla.py)*

------
https://chatgpt.com/codex/tasks/task_e_684a020fb4bc833082a33466232ce6bd