### PR TITLE
feat: ajustar rutas SLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ El comportamiento de SandyBot se ajusta mediante varias variables de entorno:
 
 - `PLANTILLA_PATH`: ruta de la plantilla para los informes de repetitividad. Si
 
-- `SLA_TEMPLATE_PATH`: ruta de la plantilla para el Informe de SLA. Si no se define, se usa `C:\Metrotel\Sandy\Template Informe SLA.docx`.
+- `SLA_TEMPLATE_PATH`: ruta de la plantilla para el Informe de SLA. Si no se define, se usa `Sandy bot/templates/Template Informe SLA.docx`.
 
 - `SIGNATURE_PATH`: ruta a la firma opcional que se agregará en los correos.
 - `GPT_MODEL`: modelo de OpenAI a emplear. Por defecto se aplica `gpt-4`.
@@ -76,7 +76,7 @@ repetitividad y otro que permite exportar el informe final a PDF.
 
 Para los reportes de nivel de servicio se utiliza un archivo Word
 configurable por `SLA_TEMPLATE_PATH`. Si la variable no está presente,
-se recurre a `C:\Metrotel\Sandy\Template Informe SLA.docx`.
+se recurre a `Sandy bot/templates/Template Informe SLA.docx`.
 El sistema valida que la ruta indicada exista. En caso de no
 encontrarla se registra el mensaje **"Plantilla de SLA no encontrada"**
 y se lanza `ValueError`.
@@ -293,8 +293,8 @@ pip install -r requirements.txt
 
 ## Informe de SLA
 
-Este flujo genera un reporte basado en el documento `Template Informe SLA.docx`, ubicado por defecto en `C:\Metrotel\Sandy`. Para iniciarlo presioná **Informe de SLA** en el menú principal o ejecutá `/informe_sla`.
-Al activarse se usa la plantilla indicada por `SLA_TEMPLATE_PATH`. Si no se define, se toma `C:\Metrotel\Sandy\Template Informe SLA.docx`.
+Este flujo genera un reporte basado en el documento `Template Informe SLA.docx`, ubicado por defecto en `Sandy bot/templates`. Para iniciarlo presioná **Informe de SLA** en el menú principal o ejecutá `/informe_sla`.
+Al activarse se usa la plantilla indicada por `SLA_TEMPLATE_PATH`. Si no se define, se toma `Sandy bot/templates/Template Informe SLA.docx`.
 El archivo debe existir en formato `.docx`.
 
 El bot solicitará primero el Excel de **reclamos** y luego el de **servicios**. Estos archivos se pueden enviar por separado. Una vez que el bot recibe ambos aparecerá el botón **Procesar**, que genera el informe utilizando la plantilla configurada en `SLA_TEMPLATE_PATH`. El documento se crea automáticamente con los campos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora** en blanco.

--- a/Sandy bot/README.md
+++ b/Sandy bot/README.md
@@ -72,7 +72,7 @@ DB_NAME=sandybot
 DB_USER=your_db_user
 DB_PASSWORD=your_db_password
 PLANTILLA_PATH=C:\Metrotel\Sandy\plantilla_informe.docx
-SLA_TEMPLATE_PATH=C:\Metrotel\Sandy\Template Informe SLA.docx
+SLA_TEMPLATE_PATH=Sandy bot/templates/Template Informe SLA.docx
 ```
 
 ## Uso
@@ -177,7 +177,7 @@ adicional.
      funciona en Windows. En otros sistemas puede generarse el archivo .docx
      sin esta modificación o realizar los cambios de forma manual.
 7. Informe de SLA
-   - Genera un resumen de nivel de servicio usando `Template Informe SLA.docx`
+   - Genera un resumen de nivel de servicio usando `Template Informe SLA.docx` ubicado por defecto en `Sandy bot/templates`
    - Podés iniciarlo desde el botón **Informe de SLA** o con `/informe_sla`
    - Solicita los Excel de reclamos y servicios, que pueden enviarse por separado
    - Una vez cargados los dos archivos aparecen los botones **Procesar** y **Exportar a PDF** para generar el informe según `SLA_TEMPLATE_PATH`
@@ -191,7 +191,7 @@ adicional.
 
 ## Informe de SLA
 
-Esta opcion genera un documento de nivel de servicio basado en `Template Informe SLA.docx`.
+Esta opcion genera un documento de nivel de servicio basado en `Template Informe SLA.docx`, ubicado por defecto en `Sandy bot/templates`.
 Podes iniciarla desde el boton **Informe de SLA** o con el comando `/informe_sla`.
 El bot pedirá primero el Excel de **reclamos** y luego el de **servicios**. Podés enviarlos por separado sin importar el orden.
 Cuando ambos estén disponibles aparecerá un botón **Procesar**, que genera el informe usando la plantilla definida en `SLA_TEMPLATE_PATH`. El documento se crea automáticamente con los textos de **Eventos destacados**, **Conclusión** y **Propuesta de mejora** en blanco.

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -47,10 +47,14 @@ class Config:
         # Carpeta para conservar trackings anteriores
         self.HISTORICO_DIR = self.DATA_DIR / "historico"
 
+        # Plantillas y reportes de SLA
+        self.SLA_HISTORIAL_DIR = self.BASE_DIR / "templates" / "Historios"
+
         # Crear directorios necesarios
         self.DATA_DIR.mkdir(exist_ok=True)
         self.LOG_DIR.mkdir(exist_ok=True)
         self.HISTORICO_DIR.mkdir(exist_ok=True)
+        self.SLA_HISTORIAL_DIR.mkdir(parents=True, exist_ok=True)
 
         # API Keys
         self.TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
@@ -87,8 +91,9 @@ class Config:
         # "SLA_TEMPLATE_PATH" permite ajustar la ubicación sin tocar el código
         self.SLA_PLANTILLA_PATH = os.getenv(
             "SLA_TEMPLATE_PATH",
-            r"C:\\Metrotel\\Sandy\\Template Informe SLA.docx",
+            str(self.BASE_DIR / "templates" / "Template Informe SLA.docx"),
         )
+        Path(self.SLA_PLANTILLA_PATH).parent.mkdir(parents=True, exist_ok=True)
         # Firma opcional en correos
         self.SIGNATURE_PATH = os.getenv("SIGNATURE_PATH")
 

--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -133,7 +133,10 @@ async def procesar_informe_sla(
         return
 
     # ─── Recepción de archivos Excel ────────────────────────────────
-    docs = [d for d in (getattr(mensaje, "document", None), *getattr(mensaje, "documents", [])) if d]
+    docs = []
+    for d in (getattr(mensaje, "document", None), *getattr(mensaje, "documents", [])):
+        if d and all(d is not x for x in docs):
+            docs.append(d)
     if docs:
         for doc in docs:
             archivo = await doc.get_file()
@@ -327,11 +330,11 @@ def _generar_documento_sla(
                 from docx2pdf import convert  # type: ignore
 
                 convert(ruta_docx, ruta_pdf)
-                converted = True
+                convertido = True
             except Exception:  # pragma: no cover
                 logger.warning("No fue posible convertir a PDF con docx2pdf")
 
-        if converted:
+        if convertido:
             os.remove(ruta_docx)
             return ruta_pdf
 

--- a/tests/telegram_stub.py
+++ b/tests/telegram_stub.py
@@ -9,6 +9,7 @@ class Message:
     def __init__(self, text="", document=None, voice=None):
         self.text = text
         self.document = document
+        self.documents = [document] if document else []
         self.documento = None
         self.voice = voice
         self.sent = None


### PR DESCRIPTION
## Summary
- crear carpeta templates para informes de SLA
- actualizar ruta por defecto de SLA_TEMPLATE_PATH
- documentar nuevo valor por defecto en ambas guías
- evitar archivos duplicados al recibir documentos
- mejorar exportación a PDF y stub de Telegram

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a173931e08330bdcac3417e36736f