### PR TITLE
Add table Reclamo and register complaints

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Se incluyen dos modelos principales:
    `tipo_tarea`, `tiempo_afectacion`, `descripcion` y `carrier_id`.
 6. **TareaServicio**: vincula cada tarea programada con los servicios
    afectados mediante sus IDs.
+7. **Reclamo**: almacena los tickets asociados a un servicio. Guarda
+   número, fecha de inicio y una descripción opcional.
 
 Antes de crear la instancia del bot se ejecuta `init_db()` desde
 `main.py`. Esta función crea las tablas y ejecuta

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -332,3 +332,20 @@ def test_crear_tarea_servicio_repetido():
             "Mantenimiento",
             [s.id, s.id],
         )
+
+
+def test_reclamos_por_servicio():
+    srv1 = bd.crear_servicio(nombre="SrvRec1", cliente="Cli")
+    srv2 = bd.crear_servicio(nombre="SrvRec2", cliente="Cli")
+    fecha = datetime(2024, 5, 1, 12)
+    bd.crear_reclamo(srv1.id, "R1", fecha_inicio=fecha, descripcion="Desc")
+    bd.crear_reclamo(srv2.id, "R2")
+
+    recs1 = bd.obtener_reclamos_servicio(srv1.id)
+    recs2 = bd.obtener_reclamos_servicio(srv2.id)
+
+    assert len(recs1) == 1
+    assert recs1[0].numero == "R1"
+    assert recs1[0].fecha_inicio == fecha
+    assert len(recs2) == 1
+    assert recs2[0].numero == "R2"


### PR DESCRIPTION
## Summary
- agregar modelo `Reclamo` y funciones para crear y consultar
- guardar reclamos al procesar el informe de SLA
- documentar la nueva tabla en README
- probar creación y recuperación de reclamos

## Testing
- `./setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac4a248ac8330a5c7dd54b82ff843