### PR TITLE
Extensión de campos en Reclamo

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Se incluyen dos modelos principales:
 6. **TareaServicio**: vincula cada tarea programada con los servicios
    afectados mediante sus IDs.
 7. **Reclamo**: almacena los tickets asociados a un servicio. Guarda
-   número, fecha de inicio y una descripción opcional.
+   número, fecha de inicio, fecha de cierre, tipo de solución y una
+   descripción de la solución.
 
 Antes de crear la instancia del bot se ejecuta `init_db()` desde
 `main.py`. Esta función crea las tablas y ejecuta

--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -156,10 +156,17 @@ class Reclamo(Base):
     servicio_id = Column(Integer, ForeignKey("servicios.id"), index=True)
     numero = Column(String, index=True)
     fecha_inicio = Column(DateTime, index=True, nullable=True)
+    fecha_cierre = Column(DateTime, index=True, nullable=True)
+    tipo_solucion = Column(String)
+    descripcion_solucion = Column(String)
     descripcion = Column(String)
 
     def __repr__(self) -> str:
-        return f"<Reclamo(id={self.id}, servicio={self.servicio_id}, numero={self.numero})>"
+        return (
+            "<Reclamo("
+            f"id={self.id}, servicio={self.servicio_id}, numero={self.numero}, "
+            f"tipo_solucion={self.tipo_solucion})>"
+        )
 
 
 class TareaProgramada(Base):
@@ -607,6 +614,9 @@ def crear_reclamo(
     numero: str,
     fecha_inicio: datetime | None = None,
     descripcion: str | None = None,
+    fecha_cierre: datetime | None = None,
+    tipo_solucion: str | None = None,
+    descripcion_solucion: str | None = None,
 ) -> Reclamo:
     """Guarda un reclamo asociado a un servicio."""
     with SessionLocal() as session:
@@ -614,6 +624,9 @@ def crear_reclamo(
             servicio_id=servicio_id,
             numero=numero,
             fecha_inicio=fecha_inicio,
+            fecha_cierre=fecha_cierre,
+            tipo_solucion=tipo_solucion,
+            descripcion_solucion=descripcion_solucion,
             descripcion=descripcion,
         )
         session.add(reclamo)

--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -65,8 +65,27 @@ def _guardar_reclamos(df: pd.DataFrame) -> None:
             if c in df.columns and not pd.isna(fila.get(c)):
                 fecha = pd.to_datetime(fila[c], errors="coerce")
                 break
-        descripcion = fila.get("Tipo Solución Reclamo")
-        bd.crear_reclamo(sid_int, str(numero), fecha_inicio=fecha, descripcion=descripcion)
+
+        cierre = None
+        if (
+            "Fecha Cierre Problema Reclamo" in df.columns
+            and not pd.isna(fila.get("Fecha Cierre Problema Reclamo"))
+        ):
+            cierre = pd.to_datetime(
+                fila["Fecha Cierre Problema Reclamo"], errors="coerce"
+            )
+
+        tipo_sol = fila.get("Tipo Solución Reclamo")
+        desc_sol = fila.get("Descripción Solución Reclamo")
+
+        bd.crear_reclamo(
+            sid_int,
+            str(numero),
+            fecha_inicio=fecha,
+            fecha_cierre=cierre,
+            tipo_solucion=tipo_sol,
+            descripcion_solucion=desc_sol,
+        )
 
 
 def identificar_excel(path: str) -> str:

--- a/Sandy bot/sandybot/handlers/repetitividad.py
+++ b/Sandy bot/sandybot/handlers/repetitividad.py
@@ -190,13 +190,17 @@ def generar_informe_y_modificar(ruta_excel):
         logger.error("Error leyendo el Excel %s: %s", ruta_excel, exc)
         raise ValueError("⚠️ No se pudo leer el Excel. Verificá el archivo.") from exc
 
+    cierre_col = 'Fecha Cierre Reclamo'
+    if 'Fecha Cierre Problema Reclamo' in casos_df.columns:
+        cierre_col = 'Fecha Cierre Problema Reclamo'
+
     columnas_a_conservar_casos = [
         'Número Reclamo',
         'Número Línea',
         'Tipo Servicio',
         'Nombre Cliente',
         'Fecha Inicio Reclamo',
-        'Fecha Cierre Reclamo',
+        cierre_col,
         'Tipo Solución Reclamo',
         'Descripción Solución Reclamo',
     ]
@@ -209,6 +213,8 @@ def generar_informe_y_modificar(ruta_excel):
         )
 
     casos_limpio = casos_df[columnas_a_conservar_casos]
+    if cierre_col != 'Fecha Cierre Reclamo':
+        casos_limpio.rename(columns={cierre_col: 'Fecha Cierre Reclamo'}, inplace=True)
     try:
         valor_fecha = casos_limpio['Fecha Cierre Reclamo'].dropna().iloc[0]
         fecha_cierre = pd.to_datetime(valor_fecha)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -338,7 +338,15 @@ def test_reclamos_por_servicio():
     srv1 = bd.crear_servicio(nombre="SrvRec1", cliente="Cli")
     srv2 = bd.crear_servicio(nombre="SrvRec2", cliente="Cli")
     fecha = datetime(2024, 5, 1, 12)
-    bd.crear_reclamo(srv1.id, "R1", fecha_inicio=fecha, descripcion="Desc")
+    cierre = datetime(2024, 5, 2, 14)
+    bd.crear_reclamo(
+        srv1.id,
+        "R1",
+        fecha_inicio=fecha,
+        fecha_cierre=cierre,
+        tipo_solucion="TS",
+        descripcion_solucion="Sol",
+    )
     bd.crear_reclamo(srv2.id, "R2")
 
     recs1 = bd.obtener_reclamos_servicio(srv1.id)
@@ -347,5 +355,8 @@ def test_reclamos_por_servicio():
     assert len(recs1) == 1
     assert recs1[0].numero == "R1"
     assert recs1[0].fecha_inicio == fecha
+    assert recs1[0].fecha_cierre == cierre
+    assert recs1[0].tipo_solucion == "TS"
+    assert recs1[0].descripcion_solucion == "Sol"
     assert len(recs2) == 1
     assert recs2[0].numero == "R2"


### PR DESCRIPTION
## Summary
- ampliar tabla `Reclamo` con fecha de cierre y datos de solución
- registrar estos datos desde `_guardar_reclamos`
- considerar columnas nuevas en repetitividad
- probar almacenamiento de nuevos campos
- documentar las columnas adicionales en README

## Testing
- `./setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aced0c688833088c117f640cf2472