### PR TITLE
Agregar restricciones únicas y evitar duplicados

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Se incluyen dos modelos principales:
 7. **Reclamo**: almacena los tickets asociados a un servicio. Guarda
    número, fecha de inicio, fecha de cierre, tipo de solución y una
    descripción de la solución.
+8. Las tablas `camaras` y `reclamos` cuentan con restricciones únicas que
+   evitan registrar dos veces la misma cámara o número de reclamo.
+   Además, al cargar el Excel de reclamos se ignoran las líneas repetidas.
 
 Antes de crear la instancia del bot se ejecuta `init_db()` desde
 `main.py`. Esta función crea las tablas y ejecuta

--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -60,6 +60,10 @@ def _guardar_reclamos(df: pd.DataFrame) -> None:
             sid_int = int(str(sid).replace(".0", ""))
         except ValueError:
             continue
+
+        existentes = bd.obtener_reclamos_servicio(sid_int)
+        if any(r.numero == str(numero) for r in existentes):
+            continue
         fecha = None
         for c in ["Fecha Inicio Reclamo", "Fecha Inicio Problema Reclamo"]:
             if c in df.columns and not pd.isna(fila.get(c)):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -360,3 +360,33 @@ def test_reclamos_por_servicio():
     assert recs1[0].descripcion_solucion == "Sol"
     assert len(recs2) == 1
     assert recs2[0].numero == "R2"
+
+
+def test_reclamo_unico():
+    """Reclamo con el mismo número no debe duplicarse."""
+    srv = bd.crear_servicio(nombre="SrvDup", cliente="Cli")
+    r1 = bd.crear_reclamo(srv.id, "DUP")
+    r2 = bd.crear_reclamo(srv.id, "DUP")
+    with bd.SessionLocal() as s:
+        filas = (
+            s.query(bd.Reclamo)
+            .filter(bd.Reclamo.servicio_id == srv.id)
+            .all()
+        )
+    assert len(filas) == 1
+    assert r1.id == r2.id
+
+
+def test_camara_unica():
+    """Cámara repetida para un servicio retorna el mismo registro."""
+    srv = bd.crear_servicio(nombre="SrvCam", cliente="Cli")
+    c1 = bd.crear_camara("Cam", srv.id)
+    c2 = bd.crear_camara("Cam", srv.id)
+    with bd.SessionLocal() as s:
+        filas = (
+            s.query(bd.Camara)
+            .filter(bd.Camara.id_servicio == srv.id)
+            .all()
+        )
+    assert len(filas) == 1
+    assert c1.id == c2.id


### PR DESCRIPTION
## Summary
- agregar restricciones a tablas `camaras` y `reclamos`
- prevenir duplicados al crear reclamos y cámaras
- ignorar reclamos repetidos al cargar el Excel de SLA
- documentar las nuevas reglas en README
- actualizar pruebas de base de datos

## Testing
- `./setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad35be92883308ad3ebbd251930d4