### PR TITLE
style: agregar encabezados obligatorios

### DIFF
--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -1,3 +1,6 @@
+# Nombre de archivo: config.py
+# Ubicación de archivo: Sandy bot/sandybot/config.py
+# User-provided custom instructions: Siemple escribe en español y explica en detalles para que sirven las lineas modificadas, agregadas o quitadas.
 """Configuración centralizada para el bot Sandy.
 
 Este módulo concentra la lectura de todas las variables de entorno

--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -1,3 +1,6 @@
+# Nombre de archivo: informe_sla.py
+# Ubicación de archivo: Sandy bot/sandybot/handlers/informe_sla.py
+# User-provided custom instructions: Siemple escribe en español y explica en detalles para que sirven las lineas modificadas, agregadas o quitadas.
 """Handler para generar informes de SLA."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- añadir cabecera con instrucciones al inicio de cada módulo

## Testing
- `pytest -q` *(fallan 4 tests)*

------
https://chatgpt.com/codex/tasks/task_e_684b652616d08330a0ae03fe3ef5d08a