### PR TITLE
Fix config path for SLA history

### DIFF
--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -50,10 +50,6 @@ class Config:  # pylint: disable=too-many-instance-attributes
             os.getenv("SLA_HISTORIAL_DIR", self.BASE_DIR / "templates" / "Historicos")
         )
 
-        # Plantillas y reportes de SLA
-        self.SLA_HISTORIAL_DIR = self.BASE_DIR / "templates" / "Historicos"
-
-
         # Crear carpetas necesarias (idempotente)
         for carpeta in (
             self.DATA_DIR,


### PR DESCRIPTION
## Summary
- remove duplicated assignment that overwrote `SLA_HISTORIAL_DIR`

## Testing
- `pytest -q` *(fails: tests/test_informe_sla.py::test_tablas_por_servicio)*

------
https://chatgpt.com/codex/tasks/task_e_684b6b6794048330966680d1dd6a017d