### PR TITLE
Mejoras en la generación de tablas SLA

### DIFF
--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -314,18 +314,12 @@ def _generar_documento_sla(
     doc = Document(RUTA_PLANTILLA)
     cuerpo = doc._body._element
 
-    # Quitar cualquier título previo para evitar duplicados
+    # El título en la plantilla está en un cuadro de texto.
+    # Si hubiera algún párrafo con ese mismo contenido se elimina
+    # para evitar duplicados como "1. Informe SLA ...".
     for p in list(doc.paragraphs):
         if "Informe SLA" in p.text:
             cuerpo.remove(p._p)
-
-    # Insertar un único encabezado al inicio del documento
-    try:
-        titulo = doc.add_heading(f"Informe SLA {mes} {anio}", level=0)
-    except KeyError:  # pragma: no cover - compatibilidad con estilos
-        titulo = doc.add_heading(f"Informe SLA {mes} {anio}", level=1)
-    cuerpo.remove(titulo._p)
-    cuerpo.insert(0, titulo._p)
 
     # ── Tabla principal (se asume que la plantilla contiene ≥1 tabla) ──
     if not doc.tables:
@@ -338,7 +332,29 @@ def _generar_documento_sla(
         raise ValueError("La plantilla debe incluir tres tablas")
     tabla2_tpl, tabla3_tpl = [copy.deepcopy(t._tbl) for t in tablas_plantilla]
     cuerpo = doc._body._element
-    # Eliminar ejemplos originales
+
+    # Párrafos entre las tablas 2 y 3 para replicar el bloque
+    idx_t2 = cuerpo.index(doc.tables[1]._tbl)
+    idx_t3 = cuerpo.index(doc.tables[2]._tbl)
+    parrafos_tpl = []
+    estilos_tpl = []
+    from docx.text.paragraph import Paragraph
+    for elem in list(cuerpo[idx_t2 + 1: idx_t3]):
+        if elem.tag.endswith("p"):
+            p = Paragraph(elem, doc)
+            parrafos_tpl.append(p.text)
+            estilos_tpl.append(p.style.name if p.style else None)
+        cuerpo.remove(elem)
+
+    if not parrafos_tpl:
+        parrafos_tpl = [
+            "Eventos sucedidos de mayor impacto en SLA:",
+            "Conclusión:",
+            "Propuesta de mejora:",
+        ]
+        estilos_tpl = [None] * len(parrafos_tpl)
+
+    # Eliminar ejemplos originales de tablas
     cuerpo.remove(doc.tables[2]._tbl)
     cuerpo.remove(doc.tables[1]._tbl)
 
@@ -375,6 +391,34 @@ def _generar_documento_sla(
         total = int(td.total_seconds())
         h, m, s = total // 3600, (total % 3600) // 60, total % 60
         return f"{h:03d}:{m:02d}:{s:02d}"
+
+    def _horas_decimal(val) -> str:
+        """Convierte valores de horas a un número entero de horas."""
+        if pd.isna(val) or val == "":
+            return ""
+        s = str(val).lower().replace(",", ".")
+        s = s.replace("d\u00eda", "day").replace("d\u00edas", "day").replace("dias", "day")
+        s = s.replace("horas", "hours").replace("hora", "hours")
+        try:
+            td = pd.to_timedelta(s)
+            return str(int(td.total_seconds() // 3600))
+        except Exception:
+            try:
+                return str(int(float(s)))
+            except Exception:
+                return s
+
+    meses = ["ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"]
+
+    def _formatear_fecha(val) -> str:
+        """Devuelve la fecha en formato DD-mes-YY en castellano."""
+        try:
+            fecha_v = pd.to_datetime(val)
+        except Exception:
+            return str(val)
+        if pd.isna(fecha_v):
+            return ""
+        return f"{fecha_v.day:02d}-{meses[fecha_v.month - 1]}-{str(fecha_v.year)[2:]}"
 
     if "Horas Reclamos Todos" in servicios_df.columns:
         servicios_df["Horas Reclamos Todos"] = servicios_df["Horas Reclamos Todos"].apply(_to_timedelta).apply(_fmt_td)
@@ -426,14 +470,17 @@ def _generar_documento_sla(
             elif "sla" in titulo:
                 row.cells[1].text = valores["sla"]
 
-        # Párrafos informativos
+        # Párrafos informativos replicados desde la plantilla
         idx = cuerpo.index(elem2)
-        for etq, txt in [
-            ("Eventos sucedidos de mayor impacto en SLA:", eventos),
-            ("Conclusión:", conclusion),
-            ("Propuesta de mejora:", propuesta),
-        ]:
-            p = doc.add_paragraph(f"{etq} {txt}")
+        for base, estilo in zip(parrafos_tpl, estilos_tpl):
+            texto = base
+            if "Eventos" in base:
+                texto = f"Eventos sucedidos de mayor impacto en SLA: {eventos}".strip()
+            elif "Conclusión" in base:
+                texto = f"Conclusión: {conclusion}".strip()
+            elif "Propuesta" in base:
+                texto = f"Propuesta de mejora: {propuesta}".strip()
+            p = doc.add_paragraph(texto, style=estilo)
             cuerpo.remove(p._p)
             cuerpo.insert(idx + 1, p._p)
             idx += 1
@@ -442,19 +489,31 @@ def _generar_documento_sla(
         elem3 = copy.deepcopy(tabla3_tpl)
         cuerpo.insert(idx + 1, elem3)
         t3 = doc.tables[-1]
+        t3.style = "Table Grid"
         while len(t3.rows) > 1:
             t3._tbl.remove(t3.rows[1]._tr)
         if col_match:
             recls = reclamos_df[reclamos_df[col_match] == srv.get(col_match)]
         else:
             recls = reclamos_df
+        total_h = 0.0
         for _, rec in recls.iterrows():
             cells = t3.add_row().cells
             cells[0].text = str(rec.get("Número Línea", ""))
             cells[1].text = str(rec.get(col_ticket, ""))
-            cells[2].text = str(rec.get("Horas Netas Reclamo", ""))
+            horas = _horas_decimal(rec.get("Horas Netas Reclamo", ""))
+            cells[2].text = horas
+            try:
+                total_h += float(horas)
+            except Exception:
+                pass
             cells[3].text = str(rec.get("Tipo Solución Reclamo", ""))
-            cells[4].text = str(rec.get("Fecha Inicio Reclamo", ""))
+            cells[4].text = _formatear_fecha(rec.get("Fecha Inicio Reclamo", ""))
+
+        fila_tot = t3.add_row().cells
+        fila_tot[0].text = "Total"
+        if total_h:
+            fila_tot[2].text = str(int(total_h))
 
         # Salto de página entre servicios
         if idx_srv < total_servicios - 1:

--- a/tests/test_informe_sla.py
+++ b/tests/test_informe_sla.py
@@ -468,7 +468,7 @@ def test_titulo_unico_y_saltos(tmp_path):
     doc = Document(doc_path)
 
     titulos = [p.text for p in doc.paragraphs if "Informe SLA" in p.text]
-    assert len(titulos) == 1
+    assert len(titulos) == 0
 
     saltos = doc._element.xml.count('w:type="page"')
     filas = pd.read_excel(s)


### PR DESCRIPTION
## Summary
- convertir los textos de horas a valor decimal
- formatear fechas en español
- agregar fila total a cada tabla de reclamos
- duplicar el bloque de servicio conservando estilos y título único
- quitar párrafo duplicado y ajustar test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b7cbe1f28833087b7be6b568ac909