### PR TITLE
fix: copia segura de casos_limpio

### DIFF
--- a/Sandy bot/sandybot/handlers/repetitividad.py
+++ b/Sandy bot/sandybot/handlers/repetitividad.py
@@ -212,9 +212,11 @@ def generar_informe_y_modificar(ruta_excel):
             "⚠️ El Excel no tiene todas las columnas necesarias. Revisá el formato."
         )
 
-    casos_limpio = casos_df[columnas_a_conservar_casos]
-    if cierre_col != 'Fecha Cierre Reclamo':
-        casos_limpio.rename(columns={cierre_col: 'Fecha Cierre Reclamo'}, inplace=True)
+    casos_limpio = casos_df[columnas_a_conservar_casos].copy()
+    if cierre_col != "Fecha Cierre Reclamo":
+        casos_limpio = casos_limpio.rename(
+            columns={cierre_col: "Fecha Cierre Reclamo"}
+        )
     try:
         valor_fecha = casos_limpio['Fecha Cierre Reclamo'].dropna().iloc[0]
         fecha_cierre = pd.to_datetime(valor_fecha)
@@ -228,7 +230,6 @@ def generar_informe_y_modificar(ruta_excel):
     mes_actual = fecha_cierre.strftime("%B")
     año_actual = fecha_cierre.strftime("%Y")
 
-    casos_limpio = casos_limpio.copy()
     casos_limpio['Número Línea'] = casos_limpio['Número Línea'].astype(str).str.replace('.0', '', regex=False)
     casos_limpio = casos_limpio.sort_values(by='Número Línea')
     lineas_con_multiples_reclamos = casos_limpio['Número Línea'].value_counts()


### PR DESCRIPTION
## Summary
- corrige la generación de `casos_limpio` en repetitividad

## Testing
- `bash setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c1eefd9688330beac0df9a646541c