### PR TITLE
Add exact search option for cameras

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -509,8 +509,14 @@ def actualizar_tracking(
         session.commit()
 
 
-def buscar_servicios_por_camara(nombre_camara: str) -> list[Servicio]:
-    """Devuelve los servicios que contienen la cámara indicada."""
+def buscar_servicios_por_camara(nombre_camara: str, exacto: bool = False) -> list[Servicio]:
+    """Devuelve los servicios que contienen la cámara indicada.
+
+    :param nombre_camara: Texto a buscar en las cámaras registradas.
+    :param exacto: Si es ``True`` solo se consideran coincidencias exactas tras
+        normalizar los nombres. De lo contrario se permite que la cadena
+        buscada sea un fragmento de la cámara o viceversa.
+    """
 
     # Se utiliza un contexto ``with`` para asegurar el cierre de la sesión
     # sin necesidad de manejar excepciones de forma explícita.
@@ -548,7 +554,10 @@ def buscar_servicios_por_camara(nombre_camara: str) -> list[Servicio]:
 
             for c in camaras:
                 c_norm = normalizar_camara(str(c))
-                if fragmento in c_norm or c_norm in fragmento:
+                coincidencia = fragmento == c_norm if exacto else (
+                    fragmento in c_norm or c_norm in fragmento
+                )
+                if coincidencia:
                     resultados.append(servicio)
                     break
         return resultados

--- a/Sandy bot/sandybot/handlers/ingresos.py
+++ b/Sandy bot/sandybot/handlers/ingresos.py
@@ -62,9 +62,17 @@ async def verificar_camara(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         return
 
     nombre_camara = mensaje.text.strip()
+    exacto = False
+    if (
+        (nombre_camara.startswith("'") and nombre_camara.endswith("'"))
+        or (nombre_camara.startswith('"') and nombre_camara.endswith('"'))
+    ):
+        nombre_camara = nombre_camara[1:-1]
+        exacto = True
+
     from ..database import buscar_servicios_por_camara
 
-    servicios = buscar_servicios_por_camara(nombre_camara)
+    servicios = buscar_servicios_por_camara(nombre_camara, exacto=exacto)
 
     if not servicios:
         await responder_registrando(
@@ -354,7 +362,15 @@ async def procesar_ingresos_excel(
 
         lineas = []
         for cam in camaras:
-            servicios = buscar_servicios_por_camara(cam)
+            exacto = False
+            texto = cam
+            if (
+                (texto.startswith("'") and texto.endswith("'"))
+                or (texto.startswith('"') and texto.endswith('"'))
+            ):
+                texto = texto[1:-1]
+                exacto = True
+            servicios = buscar_servicios_por_camara(texto, exacto=exacto)
             if not servicios:
                 lineas.append(f"{cam}: sin coincidencias")
             elif len(servicios) == 1:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -63,6 +63,14 @@ def test_buscar_servicios_por_camara():
     res1 = bd.buscar_servicios_por_camara("camara central")
     assert {s.nombre for s in res1} == {"S1"}
 
+    # Búsqueda exacta encerrando el nombre entre comillas
+    res_exact = bd.buscar_servicios_por_camara("camara central", exacto=True)
+    assert {s.nombre for s in res_exact} == {"S1"}
+
+    # "central" solo debería coincidir si no se exige exactitud
+    res_no = bd.buscar_servicios_por_camara("central", exacto=True)
+    assert res_no == []
+
     res2 = bd.buscar_servicios_por_camara("gral. san martin")
     assert {s.nombre for s in res2} == {"S3"}
 
@@ -85,6 +93,9 @@ def test_buscar_servicios_por_camara_jsonb():
 
     res = bd.buscar_servicios_por_camara("camara jsonb")
     assert {s.nombre for s in res} == {"SJ1"}
+
+    res_exact = bd.buscar_servicios_por_camara("camara jsonb", exacto=True)
+    assert {s.nombre for s in res_exact} == {"SJ1"}
 
 
 def test_exportar_camaras_servicio(tmp_path):


### PR DESCRIPTION
## Summary
- improve `buscar_servicios_por_camara` to allow exact search
- detect quoted text in `verificar_camara` and Excel handler to use exact mode
- test strict camera search

## Testing
- `bash setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c624cf8408330be7e02283343b74d