### PR TITLE
Unificar contador y usar cliente GPT global

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -36,6 +36,7 @@ from .database import (
 from .utils import (
     cargar_json,
     guardar_json,
+    incrementar_contador,
 )
 
 logger = logging.getLogger(__name__)
@@ -213,27 +214,16 @@ def enviar_excel_por_correo(
         return False
 
 
-def _incrementar_contador(clave: str) -> int:
-    """Obtiene el próximo número diario para ``clave``."""
-    fecha = datetime.now().strftime("%d%m%Y")
-    data = cargar_json(config.ARCHIVO_CONTADOR)
-    key = f"{clave}_{fecha}"
-    numero = data.get(key, 0) + 1
-    data[key] = numero
-    guardar_json(data, config.ARCHIVO_CONTADOR)
-    return numero
-
-
 def generar_nombre_camaras(id_servicio: int) -> str:
     """Genera el nombre base para un Excel de cámaras."""
-    nro = _incrementar_contador("camaras")
+    nro = incrementar_contador("camaras")
     fecha = datetime.now().strftime("%d%m%Y")
     return f"Camaras_{id_servicio}_{fecha}_{nro:02d}"
 
 
 def generar_nombre_tracking(id_servicio: int) -> str:
     """Genera el nombre base para un archivo de tracking."""
-    nro = _incrementar_contador("tracking")
+    nro = incrementar_contador("tracking")
     fecha = datetime.now().strftime("%d%m%Y")
     return f"Tracking_{id_servicio}_{fecha}_{nro:02d}"
 

--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -30,7 +30,12 @@ except Exception:  # pragma: no cover
     pythoncom = None
 
 from sandybot.config import config
-from ..utils import obtener_mensaje, cargar_json, guardar_json
+from ..utils import (
+    obtener_mensaje,
+    cargar_json,
+    guardar_json,
+    incrementar_contador,
+)
 from .estado import UserState
 from ..registrador import responder_registrando, registrar_conversacion
 from .. import database as bd
@@ -40,20 +45,9 @@ RUTA_PLANTILLA = config.SLA_PLANTILLA_PATH
 logger = logging.getLogger(__name__)
 
 # ────────────────────── GENERACIÓN DE NOMBRES ───────────────────────
-def _incrementar_contador(clave: str) -> int:
-    """Devuelve el próximo número diario para ``clave``."""
-    fecha = datetime.now().strftime("%d%m%Y")
-    data = cargar_json(config.ARCHIVO_CONTADOR)
-    key = f"{clave}_{fecha}"
-    numero = data.get(key, 0) + 1
-    data[key] = numero
-    guardar_json(data, config.ARCHIVO_CONTADOR)
-    return numero
-
-
 def _nombre_base_sla() -> str:
     """Genera el nombre base del informe de SLA."""
-    nro = _incrementar_contador("sla")
+    nro = incrementar_contador("sla")
     fecha = datetime.now().strftime("%d%m%Y")
     return f"InformeSLA_{fecha}_{nro:02d}"
 

--- a/Sandy bot/sandybot/handlers/voice.py
+++ b/Sandy bot/sandybot/handlers/voice.py
@@ -5,8 +5,7 @@
 import logging
 import tempfile
 import os
-import openai
-from ..config import config
+from ..gpt_handler import gpt
 from telegram import Update
 from telegram.ext import ContextTypes
 from ..registrador import responder_registrando
@@ -15,7 +14,7 @@ from .message import message_handler
 logger = logging.getLogger(__name__)
 
 # Cliente global de OpenAI para transcribir audios
-voice_client = openai.AsyncOpenAI(api_key=config.OPENAI_API_KEY)
+voice_client = gpt.client
 
 async def voice_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Descarga el audio, lo transcribe y pasa el texto a ``message_handler``."""

--- a/Sandy bot/sandybot/utils.py
+++ b/Sandy bot/sandybot/utils.py
@@ -13,6 +13,7 @@ from typing import Dict, Any, Optional
 from pathlib import Path
 from telegram import Update, Message
 import re
+from .config import config
 
 logger = logging.getLogger(__name__)
 
@@ -153,3 +154,19 @@ def rellenar_tabla_sla(ruta_docx: str, datos: list[dict]) -> 'Document':
         celdas[4].text = str(fila["SLA Entregado"])
 
     return doc
+
+
+def incrementar_contador(clave: str) -> int:
+    """Obtiene el próximo número diario para ``clave``.
+
+    Se almacena un contador por día en ``config.ARCHIVO_CONTADOR`` y se
+    incrementa al invocar la función.  El valor actualizado se guarda
+    de inmediato y se devuelve el número resultante.
+    """
+    fecha = datetime.now().strftime("%d%m%Y")
+    data = cargar_json(config.ARCHIVO_CONTADOR)
+    key = f"{clave}_{fecha}"
+    numero = data.get(key, 0) + 1
+    data[key] = numero
+    guardar_json(data, config.ARCHIVO_CONTADOR)
+    return numero

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,3 +60,13 @@ def test_obtener_mensaje_callback():
     msg = Message("hola")
     update = Update(callback_query=CallbackQuery(message=msg))
     assert utils.obtener_mensaje(update) is msg
+
+
+def test_incrementar_contador(tmp_path):
+    utils.config.ARCHIVO_CONTADOR = tmp_path / "cont.json"
+    n1 = utils.incrementar_contador("t")
+    n2 = utils.incrementar_contador("t")
+    hoy = utils.datetime.now().strftime("%d%m%Y")
+    data = json.load(open(utils.config.ARCHIVO_CONTADOR, "r", encoding="utf-8"))
+    assert n1 == 1 and n2 == 2
+    assert data[f"t_{hoy}"] == 2


### PR DESCRIPTION
## Summary
- mover la lógica de `_incrementar_contador` a `sandybot.utils.incrementar_contador`
- usar esta nueva función en `email_utils` e `informe_sla`
- reemplazar la instancia local de OpenAI en el manejador de voz por `gpt.client`
- probar la nueva función de utilidades

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c824c7d4c8330baf37e0d89585944