### PR TITLE
feat: agregar supermenu y consultas

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ El comportamiento de SandyBot se ajusta mediante varias variables de entorno:
 - `GPT_MODEL`: modelo de OpenAI a emplear. Por defecto se aplica `gpt-4`.
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`: datos para el servidor
   de correo saliente.
+- `SUPER_PASS`: contraseña que habilita el menú de desarrollador.
 - `SMTP_USE_TLS`: controla si se inicia TLS. Si se define como `false` o se usa
   el puerto 465 se emplea `SMTP_SSL`; en caso contrario se ejecuta `starttls()`.
 - También se aceptan `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_USER` y
@@ -62,6 +63,13 @@ export NOTION_DATABASE_ID=dummy
 export DB_USER=postgres
 export DB_PASSWORD=postgres
 ```
+
+## Modo desarrollador
+
+El bot cuenta con un menú oculto para consultas internas. Se habilita
+enviando `/Supermenu <contraseña>` desde Telegram. La clave se toma de
+`SUPER_PASS` y por omisión vale `Bio123`. Al validarla se muestran los
+botones `/CDB_Servicios`, `/CDB_Reclamos` y `/CDB_Camaras`.
 
 ## Plantilla de informes de repetitividad
 

--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -44,6 +44,10 @@ from .handlers import (
     detectar_tarea_mail,
     procesar_correos,
     reenviar_aviso,
+    supermenu,
+    listar_servicios,
+    listar_reclamos,
+    listar_camaras,
 )
 
 logger = logging.getLogger(__name__)
@@ -88,6 +92,10 @@ class SandyBot:
         self.app.add_handler(CommandHandler("procesar_correos", procesar_correos))
         self.app.add_handler(CommandHandler("reenviar_aviso", reenviar_aviso))
         self.app.add_handler(CommandHandler("informe_sla", iniciar_informe_sla))
+        self.app.add_handler(CommandHandler("Supermenu", supermenu))
+        self.app.add_handler(CommandHandler("CDB_Servicios", listar_servicios))
+        self.app.add_handler(CommandHandler("CDB_Reclamos", listar_reclamos))
+        self.app.add_handler(CommandHandler("CDB_Camaras", listar_camaras))
 
         # Callbacks de botones
         self.app.add_handler(CallbackQueryHandler(callback_handler))

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -66,6 +66,8 @@ class Config:  # pylint: disable=too-many-instance-attributes
         self.NOTION_DATABASE_ID = os.getenv("NOTION_DATABASE_ID")
         self.SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
         self.SUPERVISOR_DB_ID = os.getenv("SUPERVISOR_DB_ID")
+        # Clave para habilitar el menú de superusuario
+        self.SUPER_PASS = os.getenv("SUPER_PASS", "Bio123")
 
         # 4) Archivos comunes
         self.ARCHIVO_CONTADOR = self.DATA_DIR / "contador_diario.json"

--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -752,3 +752,28 @@ def obtener_tareas_servicio(servicio_id: int) -> list[TareaProgramada]:
             .filter(TareaServicio.servicio_id == servicio_id)
             .all()
         )
+
+
+def obtener_servicios(desc: bool = True) -> list[Servicio]:
+    """Devuelve los servicios ordenados por fecha de creación."""
+    with SessionLocal() as session:
+        query = session.query(Servicio)
+        criterio = Servicio.fecha_creacion if not desc else Servicio.fecha_creacion.desc()
+        query = query.order_by(criterio)
+        return query.all()
+
+
+def obtener_reclamos(desc: bool = True) -> list[Reclamo]:
+    """Devuelve los reclamos ordenados por ID."""
+    with SessionLocal() as session:
+        query = session.query(Reclamo)
+        query = query.order_by(Reclamo.id.desc() if desc else Reclamo.id)
+        return query.all()
+
+
+def obtener_camaras(desc: bool = True) -> list[Camara]:
+    """Lista las cámaras registradas ordenadas por ID."""
+    with SessionLocal() as session:
+        query = session.query(Camara)
+        query = query.order_by(Camara.id.desc() if desc else Camara.id)
+        return query.all()

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -45,6 +45,12 @@ from .detectar_tarea_mail import detectar_tarea_mail
 from .procesar_correos import procesar_correos
 from .reenviar_aviso import reenviar_aviso
 from .listar_tareas import listar_tareas
+from .supermenu import (
+    supermenu,
+    listar_servicios,
+    listar_reclamos,
+    listar_camaras,
+)
 
 __all__ = [
     "start_handler",
@@ -88,4 +94,8 @@ __all__ = [
     "detectar_tarea_mail",
     "procesar_correos",
     "reenviar_aviso",
+    "supermenu",
+    "listar_servicios",
+    "listar_reclamos",
+    "listar_camaras",
 ]

--- a/Sandy bot/sandybot/handlers/supermenu.py
+++ b/Sandy bot/sandybot/handlers/supermenu.py
@@ -1,0 +1,119 @@
+# + Nombre de archivo: supermenu.py
+# + Ubicación de archivo: Sandy bot/sandybot/handlers/supermenu.py
+# User-provided custom instructions
+"""Comandos de acceso rápido para consultas de base."""
+
+from telegram import Update, ReplyKeyboardMarkup
+from telegram.ext import ContextTypes
+
+from ..config import config
+from ..database import (
+    obtener_servicios,
+    obtener_reclamos,
+    obtener_camaras,
+)
+from ..utils import obtener_mensaje
+from ..registrador import responder_registrando
+
+
+async def supermenu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Muestra opciones avanzadas si la contraseña coincide."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        return
+    user_id = update.effective_user.id
+    if not context.args:
+        await responder_registrando(
+            mensaje,
+            user_id,
+            mensaje.text or "Supermenu",
+            "Usá: /Supermenu <contraseña>",
+            "supermenu",
+        )
+        return
+    clave = context.args[0]
+    if clave != config.SUPER_PASS:
+        await responder_registrando(
+            mensaje,
+            user_id,
+            mensaje.text or "Supermenu",
+            "Contraseña incorrecta.",
+            "supermenu",
+        )
+        return
+    botones = [["/CDB_Servicios", "/CDB_Reclamos", "/CDB_Camaras"]]
+    markup = ReplyKeyboardMarkup(botones, resize_keyboard=True)
+    await responder_registrando(
+        mensaje,
+        user_id,
+        mensaje.text or "Supermenu",
+        "Seleccioná una opción:",
+        "supermenu",
+        reply_markup=markup,
+    )
+
+
+async def listar_servicios(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Enumera los servicios en orden descendente."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        return
+    user_id = update.effective_user.id
+    servicios = obtener_servicios(desc=True)
+    if not servicios:
+        texto = "No hay servicios registrados."
+    else:
+        texto = "Servicios:\n" + "\n".join(
+            f"{i + 1}. {s.id} {s.nombre or ''}" for i, s in enumerate(servicios)
+        )
+    await responder_registrando(
+        mensaje,
+        user_id,
+        mensaje.text or "CDB_Servicios",
+        texto,
+        "supermenu",
+    )
+
+
+async def listar_reclamos(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Muestra los reclamos de forma descendente."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        return
+    user_id = update.effective_user.id
+    reclamos = obtener_reclamos(desc=True)
+    if not reclamos:
+        texto = "No hay reclamos registrados."
+    else:
+        texto = "Reclamos:\n" + "\n".join(
+            f"{i + 1}. {r.numero or 'sin número'}" for i, r in enumerate(reclamos)
+        )
+    await responder_registrando(
+        mensaje,
+        user_id,
+        mensaje.text or "CDB_Reclamos",
+        texto,
+        "supermenu",
+    )
+
+
+async def listar_camaras(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Lista todas las cámaras registradas."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        return
+    user_id = update.effective_user.id
+    camaras = obtener_camaras(desc=True)
+    if not camaras:
+        texto = "No hay cámaras registradas."
+    else:
+        texto = "Cámaras:\n" + "\n".join(
+            f"{i + 1}. {c.nombre}" for i, c in enumerate(camaras)
+        )
+    await responder_registrando(
+        mensaje,
+        user_id,
+        mensaje.text or "CDB_Camaras",
+        texto,
+        "supermenu",
+    )

--- a/tests/telegram_stub.py
+++ b/tests/telegram_stub.py
@@ -52,12 +52,17 @@ class InlineKeyboardMarkup:
     def __init__(self, *a, **k):
         pass
 
+class ReplyKeyboardMarkup:
+    def __init__(self, *a, **k):
+        self.keyboard = a[0] if a else []
+
 telegram_mod = ModuleType("telegram")
 telegram_mod.Update = Update
 telegram_mod.Message = Message
 telegram_mod.CallbackQuery = CallbackQuery
 telegram_mod.InlineKeyboardButton = InlineKeyboardButton
 telegram_mod.InlineKeyboardMarkup = InlineKeyboardMarkup
+telegram_mod.ReplyKeyboardMarkup = ReplyKeyboardMarkup
 telegram_mod.Document = Document
 sys.modules.setdefault("telegram", telegram_mod)
 

--- a/tests/test_supermenu.py
+++ b/tests/test_supermenu.py
@@ -1,0 +1,97 @@
+# + Nombre de archivo: test_supermenu.py
+# + Ubicación de archivo: tests/test_supermenu.py
+# User-provided custom instructions
+import sys
+import importlib
+import asyncio
+from types import ModuleType, SimpleNamespace
+from pathlib import Path
+from sqlalchemy.orm import sessionmaker
+import os
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT_DIR / "Sandy bot"))
+
+from tests.telegram_stub import Message, Update
+
+# Stub dotenv
+dotenv_stub = ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+# Variables mínimas
+os.environ.update({
+    "TELEGRAM_TOKEN": "x",
+    "OPENAI_API_KEY": "x",
+    "NOTION_TOKEN": "x",
+    "NOTION_DATABASE_ID": "x",
+    "DB_USER": "u",
+    "DB_PASSWORD": "p",
+    "SLACK_WEBHOOK_URL": "x",
+    "SUPERVISOR_DB_ID": "x",
+    "SUPER_PASS": "Bio123",
+    "DB_HOST": "localhost",
+    "DB_PORT": "5432",
+    "DB_NAME": "sandy",
+})
+
+import sqlalchemy
+orig_engine = sqlalchemy.create_engine
+sqlalchemy.create_engine = lambda *a, **k: orig_engine("sqlite:///:memory:")
+import sandybot.database as bd
+sqlalchemy.create_engine = orig_engine
+bd.SessionLocal = sessionmaker(bind=bd.engine, expire_on_commit=False)
+bd.Base.metadata.create_all(bind=bd.engine)
+
+captura = {}
+registrador_stub = ModuleType("sandybot.registrador")
+async def responder_registrando(*a, **k):
+    captura["texto"] = a[3]
+    captura["markup"] = k.get("reply_markup")
+registrador_stub.responder_registrando = responder_registrando
+registrador_stub.registrar_conversacion = lambda *a, **k: None
+sys.modules["sandybot.registrador"] = registrador_stub
+
+
+def _importar():
+    pkg = "sandybot.handlers"
+    if pkg not in sys.modules:
+        handlers_pkg = ModuleType(pkg)
+        handlers_pkg.__path__ = [str(ROOT_DIR / "Sandy bot" / "sandybot" / "handlers")]
+        sys.modules[pkg] = handlers_pkg
+    mod_name = f"{pkg}.supermenu"
+    sys.modules["sandybot.registrador"] = registrador_stub
+    spec = importlib.util.spec_from_file_location(mod_name, ROOT_DIR / "Sandy bot" / "sandybot" / "handlers" / "supermenu.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+async def _run(func, args):
+    mod = _importar()
+    msg = Message(f"/{func}")
+    update = Update(message=msg)
+    ctx = SimpleNamespace(args=args)
+    captura.clear()
+    await getattr(mod, func)(update, ctx)
+    return captura
+
+
+def test_supermenu_teclado():
+    res = asyncio.run(_run("supermenu", ["Bio123"]))
+    assert res["markup"].keyboard[0] == ["/CDB_Servicios", "/CDB_Reclamos", "/CDB_Camaras"]
+
+
+def test_listar_descendente():
+    s1 = bd.crear_servicio(nombre="S1", cliente="A")
+    s2 = bd.crear_servicio(nombre="S2", cliente="B")
+    bd.crear_reclamo(s1.id, "R1")
+    bd.crear_reclamo(s2.id, "R2")
+    bd.crear_camara("C1", s1.id)
+    bd.crear_camara("C2", s2.id)
+    texto_serv = asyncio.run(_run("listar_servicios", []))["texto"]
+    assert texto_serv.splitlines()[1].startswith("1. ") and str(s2.id) in texto_serv.splitlines()[1]
+    texto_rec = asyncio.run(_run("listar_reclamos", []))["texto"]
+    assert texto_rec.splitlines()[1].startswith("1. ") and "R2" in texto_rec.splitlines()[1]
+    texto_cam = asyncio.run(_run("listar_camaras", []))["texto"]
+    assert texto_cam.splitlines()[1].startswith("1. ") and "C2" in texto_cam.splitlines()[1]


### PR DESCRIPTION
## Summary
- agregar contraseña `SUPER_PASS` en la configuración
- crear módulo `supermenu` con menú para consultas
- exponer y registrar comandos de superusuario
- nuevas funciones para obtener servicios, reclamos y cámaras
- ordenar servicios por fecha de creación
- adaptar stub de telegram y pruebas para el supermenú
- documentar variable `SUPER_PASS` y el modo desarrollador

## Testing
- `./setup_env.sh`
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c813845a08330b57c7602e762e55d