### PR TITLE
Centraliza configuración de pruebas

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,53 @@
+# + Nombre de archivo: conftest.py
+# + Ubicación de archivo: tests/conftest.py
+# User-provided custom instructions
+import sys
+import os
+from types import ModuleType
+from pathlib import Path
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+PKG_PATH = ROOT_DIR / "Sandy bot"
+if str(PKG_PATH) not in sys.path:
+    sys.path.insert(0, str(PKG_PATH))
+
+import tests.telegram_stub  # Registra telegram y telegram.ext
+
+dotenv_stub = ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+openai_stub = ModuleType("openai")
+
+class AsyncOpenAI:
+    def __init__(self, api_key=None):
+        self.chat = type(
+            "c", (), {"completions": type("comp", (), {"create": lambda *a, **k: None})()}
+        )()
+
+openai_stub.AsyncOpenAI = AsyncOpenAI
+sys.modules.setdefault("openai", openai_stub)
+
+REQUIRED_VARS = {
+    "TELEGRAM_TOKEN": "x",
+    "OPENAI_API_KEY": "x",
+    "NOTION_TOKEN": "x",
+    "NOTION_DATABASE_ID": "x",
+    "DB_USER": "x",
+    "DB_PASSWORD": "x",
+    "SLACK_WEBHOOK_URL": "x",
+    "SUPERVISOR_DB_ID": "x",
+}
+for key, val in REQUIRED_VARS.items():
+    os.environ.setdefault(key, val)
+
+
+@pytest.fixture(autouse=True)
+def entorno_sandy(monkeypatch):
+    """Reinicia variables de entorno y ruta para cada prueba."""
+    monkeypatch.syspath_prepend(str(PKG_PATH))
+    for k, v in REQUIRED_VARS.items():
+        monkeypatch.setenv(k, os.getenv(k, v))
+    yield

--- a/tests/test_carriers.py
+++ b/tests/test_carriers.py
@@ -7,32 +7,10 @@ import asyncio
 from types import ModuleType, SimpleNamespace
 from pathlib import Path
 from sqlalchemy.orm import sessionmaker
-import os
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 from tests.telegram_stub import Message, Update
-
-# Stub de dotenv para Config
-dotenv_stub = ModuleType("dotenv")
-dotenv_stub.load_dotenv = lambda *a, **k: None
-sys.modules.setdefault("dotenv", dotenv_stub)
-
-# Variables de entorno mínimas
-os.environ.update({
-    "TELEGRAM_TOKEN": "x",
-    "OPENAI_API_KEY": "x",
-    "NOTION_TOKEN": "x",
-    "NOTION_DATABASE_ID": "x",
-    "DB_USER": "u",
-    "DB_PASSWORD": "p",
-    "SLACK_WEBHOOK_URL": "x",
-    "SUPERVISOR_DB_ID": "x",
-    "DB_HOST": "localhost",
-    "DB_PORT": "5432",
-    "DB_NAME": "sandy",
-})
 
 import sqlalchemy
 orig_engine = sqlalchemy.create_engine

--- a/tests/test_clasificar_flujo.py
+++ b/tests/test_clasificar_flujo.py
@@ -8,26 +8,11 @@ from types import ModuleType
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 # Stub de dotenv necesario para importar config
 dotenv_stub = ModuleType("dotenv")
 dotenv_stub.load_dotenv = lambda *a, **k: None
 sys.modules.setdefault("dotenv", dotenv_stub)
-
-# Variables de entorno minimas
-import os
-for var in [
-    "TELEGRAM_TOKEN",
-    "OPENAI_API_KEY",
-    "NOTION_TOKEN",
-    "NOTION_DATABASE_ID",
-    "DB_USER",
-    "DB_PASSWORD",
-    "SLACK_WEBHOOK_URL",
-    "SUPERVISOR_DB_ID",
-]:
-    os.environ.setdefault(var, "x")
 
 # Importar configuración
 importlib.import_module("sandybot.config")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,7 +1,6 @@
 # + Nombre de archivo: test_database.py
 # + Ubicación de archivo: tests/test_database.py
 # User-provided custom instructions
-import os
 import sys
 import importlib
 from pathlib import Path
@@ -15,32 +14,8 @@ from sqlalchemy.orm import sessionmaker
 
 # Agregar ruta del paquete
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 import tests.telegram_stub  # Registra las clases fake de telegram
-
-# Stub de dotenv requerido por config
-dotenv_stub = importlib.util.module_from_spec(
-    importlib.machinery.ModuleSpec("dotenv", None)
-)
-dotenv_stub.load_dotenv = lambda *a, **k: None
-sys.modules.setdefault("dotenv", dotenv_stub)
-
-# Variables de entorno necesarias para Config
-required_vars = {
-    "TELEGRAM_TOKEN": "x",
-    "OPENAI_API_KEY": "x",
-    "NOTION_TOKEN": "x",
-    "NOTION_DATABASE_ID": "x",
-    "DB_USER": "user",
-    "DB_PASSWORD": "pass",
-    "SLACK_WEBHOOK_URL": "x",
-    "SUPERVISOR_DB_ID": "x",
-    "DB_HOST": "localhost",
-    "DB_PORT": "5432",
-    "DB_NAME": "sandy",
-}
-os.environ.update(required_vars)
 
 # Forzar que ``sandybot.database`` utilice SQLite en memoria
 import sqlalchemy

--- a/tests/test_destinatarios.py
+++ b/tests/test_destinatarios.py
@@ -7,32 +7,9 @@ import asyncio
 from types import ModuleType, SimpleNamespace
 from pathlib import Path
 from sqlalchemy.orm import sessionmaker
-import os
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
-
 from tests.telegram_stub import Message, Update
-
-# Stub de dotenv para Config
-dotenv_stub = ModuleType("dotenv")
-dotenv_stub.load_dotenv = lambda *a, **k: None
-sys.modules.setdefault("dotenv", dotenv_stub)
-
-# Variables de entorno mínimas
-os.environ.update({
-    "TELEGRAM_TOKEN": "x",
-    "OPENAI_API_KEY": "x",
-    "NOTION_TOKEN": "x",
-    "NOTION_DATABASE_ID": "x",
-    "DB_USER": "u",
-    "DB_PASSWORD": "p",
-    "SLACK_WEBHOOK_URL": "x",
-    "SUPERVISOR_DB_ID": "x",
-    "DB_HOST": "localhost",
-    "DB_PORT": "5432",
-    "DB_NAME": "sandy",
-})
 
 import sqlalchemy
 orig_engine = sqlalchemy.create_engine

--- a/tests/test_detectar_tarea_mail.py
+++ b/tests/test_detectar_tarea_mail.py
@@ -8,11 +8,9 @@ from types import ModuleType, SimpleNamespace
 from pathlib import Path
 from datetime import datetime
 from sqlalchemy.orm import sessionmaker
-import os
 import tempfile
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 from tests.telegram_stub import Message, Update  # Registra las clases fake de telegram
 
@@ -30,20 +28,7 @@ jsonschema_stub.validate = lambda *a, **k: None
 jsonschema_stub.ValidationError = type("ValidationError", (Exception,), {})
 sys.modules.setdefault("jsonschema", jsonschema_stub)
 
-# Variables de entorno necesarias
-os.environ.update({
-    "TELEGRAM_TOKEN": "x",
-    "OPENAI_API_KEY": "x",
-    "NOTION_TOKEN": "x",
-    "NOTION_DATABASE_ID": "x",
-    "DB_USER": "u",
-    "DB_PASSWORD": "p",
-    "SLACK_WEBHOOK_URL": "x",
-    "SUPERVISOR_DB_ID": "x",
-    "DB_HOST": "localhost",
-    "DB_PORT": "5432",
-    "DB_NAME": "sandy",
-})
+# Variables de entorno necesarias se establecen en la fixture global
 
 # Base de datos en memoria
 import sqlalchemy

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -10,25 +10,12 @@ from pathlib import Path
 from sqlalchemy.orm import sessionmaker
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 # Stub de dotenv
 dotenv_stub = ModuleType("dotenv")
 dotenv_stub.load_dotenv = lambda *a, **k: None
 sys.modules.setdefault("dotenv", dotenv_stub)
-
-# Variables de entorno minimas
-for var in [
-    "TELEGRAM_TOKEN",
-    "OPENAI_API_KEY",
-    "NOTION_TOKEN",
-    "NOTION_DATABASE_ID",
-    "DB_USER",
-    "DB_PASSWORD",
-    "SLACK_WEBHOOK_URL",
-    "SUPERVISOR_DB_ID",
-]:
-    os.environ.setdefault(var, "x")
+# Variables de entorno minimas definidas en la fixture
 
 # Preparar base de datos en memoria
 import sqlalchemy

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -11,13 +11,7 @@ from datetime import datetime
 
 # Preparar rutas
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 import tests.telegram_stub  # Registra las clases fake de telegram
-
-# Stub de dotenv para Config
-dotenv_stub = types.ModuleType("dotenv")
-dotenv_stub.load_dotenv = lambda *a, **k: None
-sys.modules.setdefault("dotenv", dotenv_stub)
 
 # Stub de smtplib para verificar el envío
 smtp_stub = types.ModuleType("smtplib")
@@ -54,17 +48,9 @@ smtp_stub.SMTP = SMTP
 smtp_stub.SMTP_SSL = SMTP
 sys.modules["smtplib"] = smtp_stub
 
-# Variables de entorno mínimas
+# Variables de entorno adicionales para email_utils
 os.environ.update(
     {
-        "TELEGRAM_TOKEN": "x",
-        "OPENAI_API_KEY": "x",
-        "NOTION_TOKEN": "x",
-        "NOTION_DATABASE_ID": "x",
-        "DB_USER": "u",
-        "DB_PASSWORD": "p",
-        "SLACK_WEBHOOK_URL": "x",
-        "SUPERVISOR_DB_ID": "x",
         "SMTP_HOST": "smtp.example.com",
         "SMTP_PORT": "25",
         "SMTP_USER": "bot@example.com",

--- a/tests/test_gpt_cache.py
+++ b/tests/test_gpt_cache.py
@@ -9,7 +9,6 @@ import asyncio
 
 # Preparar rutas para importar el paquete
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 # Stub de telegram con las clases mínimas utilizadas por el código. De esta
 # forma evitamos la dependencia real de ``python-telegram-bot`` en las pruebas.
@@ -56,21 +55,10 @@ jsonschema_stub.validate = validate
 jsonschema_stub.ValidationError = ValidationError
 sys.modules.setdefault("jsonschema", jsonschema_stub)
 
-# Stub del paquete dotenv requerido por config
-dotenv_stub = ModuleType("dotenv")
-dotenv_stub.load_dotenv = lambda *a, **k: None
-sys.modules.setdefault("dotenv", dotenv_stub)
 
 # Variables de entorno mínimas para instanciar Config
-import os
-os.environ.setdefault("TELEGRAM_TOKEN", "x")
-os.environ.setdefault("OPENAI_API_KEY", "x")
-os.environ.setdefault("NOTION_TOKEN", "x")
-os.environ.setdefault("NOTION_DATABASE_ID", "x")
-os.environ.setdefault("DB_USER", "x")
-os.environ.setdefault("DB_PASSWORD", "x")
-os.environ.setdefault("SLACK_WEBHOOK_URL", "x")
-os.environ.setdefault("SUPERVISOR_DB_ID", "x")
+import os  # Se usa para modificar variables en otras pruebas
+# Las variables mínimas se definen en la fixture global
 
 # Importar módulos de SandyBot
 config_mod = importlib.import_module("sandybot.config")

--- a/tests/test_incidencias.py
+++ b/tests/test_incidencias.py
@@ -11,7 +11,6 @@ from docx import Document
 
 # Preparar rutas para importar el paquete
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 # Stub del módulo telegram requerido por sandybot.utils
 telegram_stub = ModuleType("telegram")
@@ -30,10 +29,6 @@ telegram_stub.Update = Update
 telegram_stub.Message = Message
 sys.modules.setdefault("telegram", telegram_stub)
 
-# Stub de dotenv requerido por config
-dotenv_stub = ModuleType("dotenv")
-dotenv_stub.load_dotenv = lambda *a, **k: None
-sys.modules.setdefault("dotenv", dotenv_stub)
 
 # Stub de openai para evitar llamadas reales
 openai_stub = ModuleType("openai")
@@ -49,19 +44,7 @@ jsonschema_stub.validate = lambda *a, **k: None
 jsonschema_stub.ValidationError = type("ValidationError", (Exception,), {})
 sys.modules.setdefault("jsonschema", jsonschema_stub)
 
-# Variables de entorno mínimas para Config
-import os
-for var in [
-    "TELEGRAM_TOKEN",
-    "OPENAI_API_KEY",
-    "NOTION_TOKEN",
-    "NOTION_DATABASE_ID",
-    "DB_USER",
-    "DB_PASSWORD",
-    "SLACK_WEBHOOK_URL",
-    "SUPERVISOR_DB_ID",
-]:
-    os.environ.setdefault(var, "x")
+# Variables de entorno mínimas para Config definidas en la fixture
 
 # Importar módulos de SandyBot
 config_mod = importlib.import_module("sandybot.config")

--- a/tests/test_informe_sla.py
+++ b/tests/test_informe_sla.py
@@ -16,27 +16,12 @@ import tempfile
 
 # ─────────────────────────── PATH DE PROYECTO ─────────────────────────
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 # ────────────────────────── STUB TELEGRAM BASE ────────────────────────
 from tests.telegram_stub import Message, Update, CallbackQuery  # type: ignore
 
 # ─────────────────── VARIABLES DE ENTORNO MÍNIMAS ─────────────────────
-dotenv_stub = ModuleType("dotenv")
-dotenv_stub.load_dotenv = lambda *a, **k: None
-sys.modules.setdefault("dotenv", dotenv_stub)
-
-for v in [
-    "TELEGRAM_TOKEN",
-    "OPENAI_API_KEY",
-    "NOTION_TOKEN",
-    "NOTION_DATABASE_ID",
-    "DB_USER",
-    "DB_PASSWORD",
-    "SLACK_WEBHOOK_URL",
-    "SUPERVISOR_DB_ID",
-]:
-    os.environ.setdefault(v, "x")
+# Las variables de entorno necesarias se definen en la fixture global
 
 # Forzar que la base use SQLite en memoria
 import sqlalchemy

--- a/tests/test_listar_tareas.py
+++ b/tests/test_listar_tareas.py
@@ -9,10 +9,8 @@ from types import ModuleType, SimpleNamespace
 from pathlib import Path
 from datetime import datetime
 from sqlalchemy.orm import sessionmaker
-import os
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 from tests.telegram_stub import Message, Update
 
@@ -37,24 +35,7 @@ registrador_stub.responder_registrando = responder_registrando
 registrador_stub.registrar_conversacion = lambda *a, **k: None
 sys.modules.setdefault("sandybot.registrador", registrador_stub)
 
-dotenv_stub = ModuleType("dotenv")
-dotenv_stub.load_dotenv = lambda *a, **k: None
-sys.modules.setdefault("dotenv", dotenv_stub)
-
-# Variables de entorno mínimas
-os.environ.update({
-    "TELEGRAM_TOKEN": "x",
-    "OPENAI_API_KEY": "x",
-    "NOTION_TOKEN": "x",
-    "NOTION_DATABASE_ID": "x",
-    "DB_USER": "u",
-    "DB_PASSWORD": "p",
-    "SLACK_WEBHOOK_URL": "x",
-    "SUPERVISOR_DB_ID": "x",
-    "DB_HOST": "localhost",
-    "DB_PORT": "5432",
-    "DB_NAME": "sandy",
-})
+# Variables de entorno mínimas definidas en la fixture
 
 import sqlalchemy
 orig_engine = sqlalchemy.create_engine

--- a/tests/test_procesar_correos.py
+++ b/tests/test_procesar_correos.py
@@ -4,14 +4,12 @@
 import asyncio
 import importlib
 import sys
-import os
 import tempfile
 from types import ModuleType, SimpleNamespace
 from pathlib import Path
 from sqlalchemy.orm import sessionmaker
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 # Stubs de telegram
 telegram_stub = ModuleType("telegram")
@@ -101,22 +99,7 @@ jsonschema_stub.validate = lambda *a, **k: None
 jsonschema_stub.ValidationError = type("ValidationError", (Exception,), {})
 sys.modules.setdefault("jsonschema", jsonschema_stub)
 
-# Variables de entorno necesarias
-os.environ.update(
-    {
-        "TELEGRAM_TOKEN": "x",
-        "OPENAI_API_KEY": "x",
-        "NOTION_TOKEN": "x",
-        "NOTION_DATABASE_ID": "x",
-        "DB_USER": "u",
-        "DB_PASSWORD": "p",
-        "SLACK_WEBHOOK_URL": "x",
-        "SUPERVISOR_DB_ID": "x",
-        "DB_HOST": "localhost",
-        "DB_PORT": "5432",
-        "DB_NAME": "sandy",
-    }
-)
+# Variables de entorno necesarias se definen en la fixture global
 
 # Base de datos en memoria
 import sqlalchemy

--- a/tests/test_supermenu.py
+++ b/tests/test_supermenu.py
@@ -7,33 +7,11 @@ import asyncio
 from types import ModuleType, SimpleNamespace
 from pathlib import Path
 from sqlalchemy.orm import sessionmaker
-import os
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 from tests.telegram_stub import Message, Update
-
-# Stub dotenv
-dotenv_stub = ModuleType("dotenv")
-dotenv_stub.load_dotenv = lambda *a, **k: None
-sys.modules.setdefault("dotenv", dotenv_stub)
-
-# Variables mínimas
-os.environ.update({
-    "TELEGRAM_TOKEN": "x",
-    "OPENAI_API_KEY": "x",
-    "NOTION_TOKEN": "x",
-    "NOTION_DATABASE_ID": "x",
-    "DB_USER": "u",
-    "DB_PASSWORD": "p",
-    "SLACK_WEBHOOK_URL": "x",
-    "SUPERVISOR_DB_ID": "x",
-    "SUPER_PASS": "Bio123",
-    "DB_HOST": "localhost",
-    "DB_PORT": "5432",
-    "DB_NAME": "sandy",
-})
+# Variables mínimas configuradas en la fixture global
 
 import sqlalchemy
 orig_engine = sqlalchemy.create_engine

--- a/tests/test_tarea_programada.py
+++ b/tests/test_tarea_programada.py
@@ -8,12 +8,10 @@ from types import ModuleType, SimpleNamespace
 from pathlib import Path
 from datetime import datetime
 from sqlalchemy.orm import sessionmaker
-import os
 import tempfile
 
 # Preparar ruta del paquete
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 from tests.telegram_stub import Message, Update  # Registra las clases fake de telegram
 
@@ -54,23 +52,7 @@ sys.modules.setdefault("sandybot.registrador", registrador_stub)
 dotenv_stub = ModuleType("dotenv")
 dotenv_stub.load_dotenv = lambda *a, **k: None
 sys.modules.setdefault("dotenv", dotenv_stub)
-
-# Variables de entorno necesarias
-os.environ.update(
-    {
-        "TELEGRAM_TOKEN": "x",
-        "OPENAI_API_KEY": "x",
-        "NOTION_TOKEN": "x",
-        "NOTION_DATABASE_ID": "x",
-        "DB_USER": "u",
-        "DB_PASSWORD": "p",
-        "SLACK_WEBHOOK_URL": "x",
-        "SUPERVISOR_DB_ID": "x",
-        "DB_HOST": "localhost",
-        "DB_PORT": "5432",
-        "DB_NAME": "sandy",
-    }
-)
+# Variables mínimas definidas en la fixture
 
 # Base de datos en memoria
 import sqlalchemy

--- a/tests/test_userstate.py
+++ b/tests/test_userstate.py
@@ -2,7 +2,6 @@
 # + Ubicación de archivo: tests/test_userstate.py
 # User-provided custom instructions
 import sys
-import os
 import importlib
 import json
 from datetime import datetime, timedelta
@@ -11,7 +10,6 @@ from types import ModuleType
 
 # Preparar entorno de importacion
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 # Stub del modulo dotenv requerido por config
 dotenv_stub = ModuleType("dotenv")
@@ -116,17 +114,7 @@ registrador_stub.responder_registrando = responder_registrando
 sys.modules.setdefault("sandybot.registrador", registrador_stub)
 
 # Variables requeridas por Config
-for var in [
-    "TELEGRAM_TOKEN",
-    "OPENAI_API_KEY",
-    "NOTION_TOKEN",
-    "NOTION_DATABASE_ID",
-    "DB_USER",
-    "DB_PASSWORD",
-    "SLACK_WEBHOOK_URL",
-    "SUPERVISOR_DB_ID",
-]:
-    os.environ.setdefault(var, "x")
+# Variables definidas en la fixture global
 
 # Importar config despues de establecer las variables
 config_mod = importlib.import_module("sandybot.config")

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -8,7 +8,6 @@ from types import ModuleType, SimpleNamespace
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR / "Sandy bot"))
 
 # Stub telegram con soporte de mensajes de voz
 telegram_stub = ModuleType("telegram")
@@ -46,17 +45,9 @@ dotenv_stub = ModuleType("dotenv")
 dotenv_stub.load_dotenv = lambda *a, **k: None
 sys.modules.setdefault("dotenv", dotenv_stub)
 
-# Variables de entorno mínimas
+# Variables de entorno adicionales
 import os
 for var in [
-    "TELEGRAM_TOKEN",
-    "OPENAI_API_KEY",
-    "NOTION_TOKEN",
-    "NOTION_DATABASE_ID",
-    "SLACK_WEBHOOK_URL",
-    "SUPERVISOR_DB_ID",
-    "DB_USER",
-    "DB_PASSWORD",
     "SMTP_HOST",
     "SMTP_PORT",
     "SMTP_USER",


### PR DESCRIPTION
## Summary
- agregar fixture global en `conftest.py`
- reutilizar la fixture en las pruebas y eliminar duplicados

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c869f5adc8330843471104baa5bb5