### PR TITLE
feat: confirmar flujos con botones

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -239,14 +239,14 @@ def enviar_excel_por_correo(
 
 def generar_nombre_camaras(id_servicio: int) -> str:
     """Genera el nombre base para un Excel de cámaras."""
-    nro = incrementar_contador("camaras")
+    nro = incrementar_contador("camaras", config.ARCHIVO_CONTADOR)
     fecha = datetime.now().strftime("%d%m%Y")
     return f"Camaras_{id_servicio}_{fecha}_{nro:02d}"
 
 
 def generar_nombre_tracking(id_servicio: int) -> str:
     """Genera el nombre base para un archivo de tracking."""
-    nro = incrementar_contador("tracking")
+    nro = incrementar_contador("tracking", config.ARCHIVO_CONTADOR)
     fecha = datetime.now().strftime("%d%m%Y")
     return f"Tracking_{id_servicio}_{fecha}_{nro:02d}"
 
@@ -505,7 +505,7 @@ async def procesar_correo_a_tarea(
             else:
                 logger.warning("Servicio %s no encontrado", ident)
 
-        if not servicios:
+        if ids_brutos and not servicios:
             logger.warning("No se localizaron servicios en el correo")
             raise ValueError("No se encontraron servicios")
 

--- a/Sandy bot/sandybot/handlers/message.py
+++ b/Sandy bot/sandybot/handlers/message.py
@@ -59,7 +59,7 @@ async def message_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         flujo_pendiente = context.user_data.get("confirmar_flujo")
         if flujo_pendiente:
             resp = normalizar_texto(mensaje_usuario)
-            if resp in ("si", "sí", "s", "ok", "dale"):
+            if resp in ("si", "sí", "s", "ok", "dale", "yes"):
                 context.user_data.pop("confirmar_flujo", None)
                 await responder_registrando(
                     update.message,
@@ -81,12 +81,25 @@ async def message_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     "sandy",
                 )
             else:
+                keyboard = InlineKeyboardMarkup(
+                    [
+                        [
+                            InlineKeyboardButton(
+                                "Sí", callback_data="confirmar_flujo_si"
+                            ),
+                            InlineKeyboardButton(
+                                "No", callback_data="confirmar_flujo_no"
+                            ),
+                        ]
+                    ]
+                )
                 await responder_registrando(
                     update.message,
                     user_id,
                     mensaje_usuario,
                     "Decí 'sí' o 'no' para confirmar.",
                     "sandy",
+                    reply_markup=keyboard,
                 )
             return
 
@@ -166,12 +179,25 @@ async def message_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     return
             if accion:
                 context.user_data["confirmar_flujo"] = accion
+                keyboard = InlineKeyboardMarkup(
+                    [
+                        [
+                            InlineKeyboardButton(
+                                "Sí", callback_data="confirmar_flujo_si"
+                            ),
+                            InlineKeyboardButton(
+                                "No", callback_data="confirmar_flujo_no"
+                            ),
+                        ]
+                    ]
+                )
                 await responder_registrando(
                     update.message,
                     user_id,
                     mensaje_usuario,
                     f"¿Deseás iniciar { _nombre_flujo(accion) }? (sí/no)",
                     "sandy",
+                    reply_markup=keyboard,
                 )
                 return
 

--- a/Sandy bot/sandybot/utils.py
+++ b/Sandy bot/sandybot/utils.py
@@ -156,17 +156,17 @@ def rellenar_tabla_sla(ruta_docx: str, datos: list[dict]) -> 'Document':
     return doc
 
 
-def incrementar_contador(clave: str) -> int:
+def incrementar_contador(clave: str, ruta: Path | None = None) -> int:
     """Obtiene el próximo número diario para ``clave``.
 
-    Se almacena un contador por día en ``config.ARCHIVO_CONTADOR`` y se
-    incrementa al invocar la función.  El valor actualizado se guarda
-    de inmediato y se devuelve el número resultante.
+    Se almacena un contador por día en ``ruta`` o en ``config.ARCHIVO_CONTADOR``
+    si no se especifica. Incrementa el valor y lo devuelve.
     """
     fecha = datetime.now().strftime("%d%m%Y")
-    data = cargar_json(config.ARCHIVO_CONTADOR)
+    destino = ruta or config.ARCHIVO_CONTADOR
+    data = cargar_json(destino)
     key = f"{clave}_{fecha}"
     numero = data.get(key, 0) + 1
     data[key] = numero
-    guardar_json(data, config.ARCHIVO_CONTADOR)
+    guardar_json(data, destino)
     return numero


### PR DESCRIPTION
## Summary
- agregar validaciones con botones sí/no
- aceptar 'yes' como respuesta afirmativa
- completar rutas en funciones de email
- permitir ruta personalizada en `incrementar_contador`
- manejar confirmación desde el callback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c95466f308330be8f2577abc4ced7