### PR TITLE
Add duplicate cleanup command

### DIFF
--- a/Sandy bot/sandybot/bot.py
+++ b/Sandy bot/sandybot/bot.py
@@ -50,6 +50,7 @@ from .handlers import (
     listar_servicios,
     listar_reclamos,
     listar_camaras,
+    depurar_duplicados,
 )
 
 logger = logging.getLogger(__name__)
@@ -101,6 +102,7 @@ class SandyBot:
         self.app.add_handler(CommandHandler("CDB_Servicios", listar_servicios))
         self.app.add_handler(CommandHandler("CDB_Reclamos", listar_reclamos))
         self.app.add_handler(CommandHandler("CDB_Camaras", listar_camaras))
+        self.app.add_handler(CommandHandler("Depurar_Duplicados", depurar_duplicados))
 
         # Callbacks de botones
         self.app.add_handler(CallbackQueryHandler(callback_handler))

--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -54,6 +54,7 @@ from .supermenu import (
     listar_servicios,
     listar_reclamos,
     listar_camaras,
+    depurar_duplicados,
 )
 
 __all__ = [
@@ -104,4 +105,5 @@ __all__ = [
     "listar_servicios",
     "listar_reclamos",
     "listar_camaras",
+    "depurar_duplicados",
 ]

--- a/Sandy bot/sandybot/handlers/supermenu.py
+++ b/Sandy bot/sandybot/handlers/supermenu.py
@@ -11,6 +11,8 @@ from ..database import (
     obtener_servicios,
     obtener_reclamos,
     obtener_camaras,
+    depurar_servicios_duplicados,
+    depurar_reclamos_duplicados,
 )
 from ..utils import obtener_mensaje
 from ..registrador import responder_registrando
@@ -41,7 +43,7 @@ async def supermenu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             "supermenu",
         )
         return
-    botones = [["/CDB_Servicios", "/CDB_Reclamos", "/CDB_Camaras"]]
+    botones = [["/CDB_Servicios", "/CDB_Reclamos", "/CDB_Camaras", "/Depurar_Duplicados"]]
     markup = ReplyKeyboardMarkup(botones, resize_keyboard=True)
     await responder_registrando(
         mensaje,
@@ -114,6 +116,28 @@ async def listar_camaras(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         mensaje,
         user_id,
         mensaje.text or "CDB_Camaras",
+        texto,
+        "supermenu",
+    )
+
+
+async def depurar_duplicados(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Elimina registros duplicados de servicios y reclamos."""
+    mensaje = obtener_mensaje(update)
+    if not mensaje:
+        return
+    user_id = update.effective_user.id
+    elim_serv = depurar_servicios_duplicados()
+    elim_rec = depurar_reclamos_duplicados()
+    texto = (
+        "Depuración completada:\n"
+        f"Servicios eliminados: {elim_serv}\n"
+        f"Reclamos eliminados: {elim_rec}"
+    )
+    await responder_registrando(
+        mensaje,
+        user_id,
+        mensaje.text or "Depurar_Duplicados",
         texto,
         "supermenu",
     )


### PR DESCRIPTION
## Summary
- depurar servicios y reclamos duplicados desde la base
- exponer el nuevo comando en el menú de desarrollador
- probar la depuración de duplicados

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c80d08b9083308f15c517c8e53239