### PR TITLE
feat: validar correos con regex

### DIFF
--- a/Sandy bot/sandybot/utils.py
+++ b/Sandy bot/sandybot/utils.py
@@ -80,6 +80,12 @@ def timestamp_log() -> str:
     """
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
+
+def es_correo_valido(correo: str) -> bool:
+    """Verifica si ``correo`` posee un formato de email válido."""
+    patron = r"^[\w.+-]+@[\w-]+\.[a-zA-Z]{2,}$"
+    return bool(re.match(patron, correo))
+
 def obtener_mensaje(update: Update) -> Optional[Message]:
     """
     Devuelve el objeto ``Message`` de un ``Update``.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,6 +56,14 @@ def test_timestamp_log_formato():
     ts = utils.timestamp_log()
     assert re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", ts)
 
+
+def test_es_correo_valido_ok():
+    assert utils.es_correo_valido("alguien@example.com") is True
+
+
+def test_es_correo_valido_falso():
+    assert utils.es_correo_valido("alguien@example") is False
+
 def test_obtener_mensaje_callback():
     msg = Message("hola")
     update = Update(callback_query=CallbackQuery(message=msg))


### PR DESCRIPTION
## Summary
- agregar `es_correo_valido` en `utils.py`
- probar validación de correos en `test_utils.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df6528cb083309d344295599d91ba