### PR TITLE
Agregar gestión de correos y resumen de tareas

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ Ejemplos:
 /listar_tareas carrier=Telecom
 ```
 El bot muestra inicio, fin, tipo y los servicios afectados.
+Si presionás **⏰ Ver tareas** en el menú se muestran las tareas en curso y
+cuánto falta para la próxima ventana.
 
 ### Avisos en formato `.MSG`
 
@@ -235,6 +237,7 @@ Además adjuntará el archivo `.MSG` en el chat para facilitar el reenvío manua
 ### Procesar correos y registrar tareas
 
 Usá `/procesar_correos` para analizar los avisos `.MSG` que reciba el bot y evitar cargar la información de forma manual. El comando extrae los datos mediante GPT y reenvía automáticamente el aviso a los destinatarios configurados.
+También podés iniciar el flujo desde el botón **📫 Procesar correos** del menú principal.
 
 Si `pywin32` está instalado los `.MSG` se crean con Outlook, por lo que podés abrirlos y editar el cuerpo antes de enviarlos. Sin esas librerías el bot genera un texto plano.
 

--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -845,6 +845,18 @@ def obtener_tareas_programadas(desc: bool = True) -> list[TareaProgramada]:
         return query.all()
 
 
+def obtener_proxima_tarea() -> TareaProgramada | None:
+    """Devuelve la tarea futura más cercana a la fecha actual."""
+    with SessionLocal() as session:
+        ahora = datetime.utcnow()
+        return (
+            session.query(TareaProgramada)
+            .filter(TareaProgramada.fecha_inicio >= ahora)
+            .order_by(TareaProgramada.fecha_inicio)
+            .first()
+        )
+
+
 def depurar_servicios_duplicados() -> int:
     """Elimina servicios con el mismo nombre y cliente dejando el más reciente."""
     with SessionLocal() as session:

--- a/Sandy bot/sandybot/handlers/callback.py
+++ b/Sandy bot/sandybot/handlers/callback.py
@@ -103,6 +103,16 @@ async def callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         registrar_conversacion(user_id, "boton_enviar_camaras_mail", "Inicio envio camaras", "callback")
         await iniciar_envio_camaras_mail(update, context)
 
+    elif data == "procesar_correos":
+        from .procesar_correos import procesar_correos
+        registrar_conversacion(user_id, "procesar_correos", "Procesar correos", "callback")
+        await procesar_correos(update, context)
+
+    elif data == "listar_tareas":
+        from .listar_tareas import mostrar_tareas
+        registrar_conversacion(user_id, "listar_tareas", "Mostrar tareas", "callback")
+        await mostrar_tareas(update, context)
+
     elif data == "id_carrier":
         from .id_carrier import iniciar_identificador_carrier
         registrar_conversacion(user_id, "boton_id_carrier", "Inicio id carrier", "callback")

--- a/Sandy bot/sandybot/handlers/start.py
+++ b/Sandy bot/sandybot/handlers/start.py
@@ -38,6 +38,10 @@ async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
            InlineKeyboardButton("🦜 Informe de SLA", callback_data="informe_sla"),
         ],
         [
+           InlineKeyboardButton("📫 Procesar correos", callback_data="procesar_correos"),
+           InlineKeyboardButton("⏰ Ver tareas", callback_data="listar_tareas"),
+        ],
+        [
            InlineKeyboardButton("📝 Analizar incidencias", callback_data="analizar_incidencias"),
         ],
         [

--- a/tests/telegram_stub.py
+++ b/tests/telegram_stub.py
@@ -25,6 +25,10 @@ class Message:
 class CallbackQuery:
     def __init__(self, message=None):
         self.message = message
+        self.from_user = SimpleNamespace(id=1)
+
+    async def answer(self, *a, **k):
+        pass
 
 class Document:
     def __init__(self, file_name="file.txt", content=""):

--- a/tests/test_callback_menu.py
+++ b/tests/test_callback_menu.py
@@ -1,0 +1,93 @@
+# Nombre de archivo: test_callback_menu.py
+# Ubicación de archivo: tests/test_callback_menu.py
+# User-provided custom instructions
+import sys
+import importlib
+import asyncio
+from types import ModuleType, SimpleNamespace
+from pathlib import Path
+from sqlalchemy.orm import sessionmaker
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+from tests.telegram_stub import Message, Update, CallbackQuery
+
+# Stubs para dependencias de otros módulos
+notion_mod = ModuleType("notion_client")
+class DummyClient:
+    def __init__(self, *a, **k):
+        pass
+notion_mod.Client = DummyClient
+sys.modules.setdefault("notion_client", notion_mod)
+sys.modules.setdefault("openai", ModuleType("openai"))
+js = ModuleType("jsonschema")
+js.validate = lambda *a, **k: None
+js.ValidationError = Exception
+sys.modules.setdefault("jsonschema", js)
+
+# Base de datos en memoria para importar el módulo
+import sqlalchemy
+orig_engine = sqlalchemy.create_engine
+sqlalchemy.create_engine = lambda *a, **k: orig_engine("sqlite:///:memory:")
+import sandybot.database as bd
+sqlalchemy.create_engine = orig_engine
+bd.SessionLocal = sessionmaker(bind=bd.engine, expire_on_commit=False)
+bd.Base.metadata.create_all(bind=bd.engine)
+
+# Stubs del registrador
+captura = {}
+registrador_stub = ModuleType("sandybot.registrador")
+async def responder_registrando(*a, **k):
+    pass
+registrador_stub.responder_registrando = responder_registrando
+registrador_stub.registrar_conversacion = lambda *a, **k: None
+sys.modules["sandybot.registrador"] = registrador_stub
+
+# Importar callback con funciones stubs
+pkg = "sandybot.handlers"
+if pkg not in sys.modules:
+    handlers_pkg = ModuleType(pkg)
+    handlers_pkg.__path__ = [str(ROOT_DIR / "Sandy bot" / "sandybot" / "handlers")]
+    sys.modules[pkg] = handlers_pkg
+spec = importlib.util.spec_from_file_location(
+    f"{pkg}.callback", ROOT_DIR / "Sandy bot" / "sandybot" / "handlers" / "callback.py"
+)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[f"{pkg}.callback"] = mod
+spec.loader.exec_module(mod)
+
+# Reemplazar funciones por stubs para detectar las llamadas
+llamadas = {}
+async def fake_proc(update, ctx):
+    llamadas["proc"] = True
+async def fake_list(update, ctx):
+    llamadas["list"] = True
+sys.modules[f"{pkg}.procesar_correos"] = ModuleType("pc")
+sys.modules[f"{pkg}.procesar_correos"].procesar_correos = fake_proc
+sys.modules[f"{pkg}.listar_tareas"] = ModuleType("lt")
+sys.modules[f"{pkg}.listar_tareas"].mostrar_tareas = fake_list
+
+
+async def _run(data):
+    msg = Message()
+    cb = CallbackQuery(message=msg)
+    cb.data = data
+    update = Update(callback_query=cb)
+    ctx = SimpleNamespace(args=[], user_data={})
+    await mod.callback_handler(update, ctx)
+
+
+def test_callback_procesar_correos():
+    asyncio.run(_run("procesar_correos"))
+    assert llamadas.get("proc") is True
+
+
+def test_callback_listar_tareas():
+    llamadas.clear()
+    asyncio.run(_run("listar_tareas"))
+    assert llamadas.get("list") is True
+
+
+def teardown_module(module):
+    sys.modules.pop(f"{pkg}.procesar_correos", None)
+    sys.modules.pop(f"{pkg}.listar_tareas", None)

--- a/tests/test_proxima_tarea.py
+++ b/tests/test_proxima_tarea.py
@@ -1,0 +1,37 @@
+# Nombre de archivo: test_proxima_tarea.py
+# Ubicación de archivo: tests/test_proxima_tarea.py
+# User-provided custom instructions
+import sys
+import importlib
+from types import ModuleType
+from pathlib import Path
+from datetime import datetime, timedelta
+from sqlalchemy.orm import sessionmaker
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+# Registrar stubs básicos de telegram
+from tests.telegram_stub import Message, Update
+
+import sqlalchemy
+orig_engine = sqlalchemy.create_engine
+sqlalchemy.create_engine = lambda *a, **k: orig_engine("sqlite:///:memory:")
+import sandybot.database as bd
+sqlalchemy.create_engine = orig_engine
+bd.SessionLocal = sessionmaker(bind=bd.engine, expire_on_commit=False)
+bd.Base.metadata.create_all(bind=bd.engine)
+
+
+def teardown_module(module):
+    bd.Base.metadata.drop_all(bind=bd.engine)
+
+
+def test_obtener_proxima_tarea():
+    srv = bd.crear_servicio(nombre="Srv", cliente="A")
+    ahora = datetime.utcnow()
+    bd.crear_tarea_programada(ahora - timedelta(hours=2), ahora - timedelta(hours=1), "Pasada", [srv.id])
+    t2 = bd.crear_tarea_programada(ahora + timedelta(hours=1), ahora + timedelta(hours=2), "Siguiente", [srv.id])
+    bd.crear_tarea_programada(ahora + timedelta(hours=3), ahora + timedelta(hours=4), "Lejana", [srv.id])
+    proxima = bd.obtener_proxima_tarea()
+    assert proxima.id == t2.id
+


### PR DESCRIPTION
## Summary
- añadir botones Procesar correos y Ver tareas en el menú principal
- incorporar nuevos callbacks para los botones
- implementar `obtener_proxima_tarea` en la base de datos
- mostrar las tareas en curso con tiempo restante
- documentar los cambios en README
- agregar pruebas para la nueva función y el menú

## Testing
- `pytest tests/test_callback_menu.py tests/test_proxima_tarea.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e95e508c083309c4359116a8ebaaa