### PR TITLE
Implementa aviso de IDs faltantes

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -490,6 +490,7 @@ async def procesar_correo_a_tarea(
                 session.refresh(carrier)
 
         servicios: list[Servicio] = []
+        ids_faltantes: list[str] = []
         for ident in ids_brutos:
             srv = None
             if ident.isdigit():
@@ -503,11 +504,16 @@ async def procesar_correo_a_tarea(
             if srv:
                 servicios.append(srv)
             else:
+                ids_faltantes.append(ident)
                 logger.warning("Servicio %s no encontrado", ident)
 
         if ids_brutos and not servicios:
-            logger.warning("No se localizaron servicios en el correo")
-            raise ValueError("No se encontraron servicios")
+            faltantes_str = ", ".join(ids_faltantes)
+            logger.warning(
+                "No se localizaron servicios en el correo. Faltantes: %s",
+                faltantes_str,
+            )
+            raise ValueError(f"No se encontraron servicios: {faltantes_str}")
 
         tarea = crear_tarea_programada(
             inicio,

--- a/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
+++ b/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
@@ -88,12 +88,20 @@ async def detectar_tarea_mail(update: Update, context: ContextTypes.DEFAULT_TYPE
 
     try:
         tarea, cliente, ruta, _ = await procesar_correo_a_tarea(
-
             contenido,
             cliente_nombre,
             carrier_nombre,
-
         )
+    except ValueError as err:
+        logger.error("Fallo detectando tarea: %s", err)
+        await responder_registrando(
+            mensaje,
+            user_id,
+            mensaje.text or getattr(mensaje.document, "file_name", ""),
+            str(err),
+            "tareas",
+        )
+        return
     except Exception as e:
         logger.error("Fallo detectando tarea: %s", e)
         await responder_registrando(

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -109,6 +109,17 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 contenido, cliente_nombre, carrier_nombre
             )
 
+        except ValueError as err:  # pragma: no cover
+            logger.error("Fallo procesando correo %s: %s", doc.file_name, err)
+            await responder_registrando(
+                mensaje,
+                user_id,
+                doc.file_name,
+                str(err),
+                "tareas",
+            )
+            os.remove(ruta_tmp)
+            continue
         except Exception as e:  # pragma: no cover
             logger.error("Fallo procesando correo %s: %s", doc.file_name, e)
             os.remove(ruta_tmp)

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -322,6 +322,7 @@ def test_procesar_correo_sin_servicios(monkeypatch, caplog):
     email_utils.gpt = GPTStub()
 
     with caplog.at_level(logging.WARNING):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as err:
             asyncio.run(email_utils.procesar_correo_a_tarea("correo", "Cli"))
-        assert "No se localizaron servicios" in caplog.text
+        assert "Faltantes: 99999" in caplog.text
+    assert "99999" in str(err.value)


### PR DESCRIPTION
## Notas
- Se añadió instalacion de dependencias para ejecutar `pytest`. 

## Summary
- registra IDs no hallados en `email_utils.procesar_correo_a_tarea`
- informa esos IDs cuando falla `procesar_correos` o `detectar_tarea_mail`
- ajusta prueba para verificar la advertencia con IDs inexistentes

## Testing
- `pytest tests/test_email_utils.py::test_procesar_correo_sin_servicios -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eab4fc6bc8330968007cddd0d0288