### PR TITLE
feat: pasar carrier a generar_archivo_msg

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -292,6 +292,7 @@ def generar_archivo_msg(
     cliente: Cliente,
     servicios: list[Servicio],
     ruta: str,
+    carrier: Carrier | None = None,
 ) -> tuple[str, str]:
     """Genera un archivo *.msg* (Outlook) o texto plano con la tarea programada.
 
@@ -303,11 +304,19 @@ def generar_archivo_msg(
     - Con ``win32`` + ``pythoncom`` disponibles → se crea un verdadero **MSG**,
       se establece asunto, cuerpo y se agrega firma (si existe).
     - Sin estas librerías → se genera un **.txt** de respaldo.
+
+    Parameters
+    ----------
+    carrier : Carrier, optional
+        Objeto ya recuperado desde la base. Si no se indica,
+        se buscará usando una nueva sesión.
     """
 
     # 📨 Contenido base
     carrier_nombre = None
-    if tarea.carrier_id:
+    if carrier:
+        carrier_nombre = carrier.nombre
+    elif tarea.carrier_id:
         with SessionLocal() as s:
             car = s.get(Carrier, tarea.carrier_id)
             carrier_nombre = car.nombre if car else None
@@ -533,6 +542,7 @@ async def procesar_correo_a_tarea(
             cliente,
             [s for s in servicios if s],
             str(ruta),
+            carrier,
         )
         ruta_msg = Path(ruta_str)
 

--- a/Sandy bot/sandybot/handlers/reenviar_aviso.py
+++ b/Sandy bot/sandybot/handlers/reenviar_aviso.py
@@ -96,7 +96,11 @@ async def reenviar_aviso(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         nombre_arch = f"tarea_{tarea.id}.msg"
         ruta_path = Path(tempfile.gettempdir()) / nombre_arch
         _, cuerpo = generar_archivo_msg(
-            tarea, cliente, [s for s in servicios if s], str(ruta_path)
+            tarea,
+            cliente,
+            [s for s in servicios if s],
+            str(ruta_path),
+            carrier,
         )
         enviar_correo(
             f"Aviso de tarea programada - {cliente.nombre}",

--- a/Sandy bot/sandybot/handlers/tarea_programada.py
+++ b/Sandy bot/sandybot/handlers/tarea_programada.py
@@ -98,6 +98,7 @@ async def registrar_tarea_programada(
             cliente,
             [s for s in servicios if s],
             str(ruta_path),
+            carrier,
         )
 
         enviar_correo(

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -233,7 +233,13 @@ def test_generar_archivo_msg(tmp_path):
     )
 
     ruta = tmp_path / "aviso.msg"
-    resultado_ruta, texto = email_utils.generar_archivo_msg(tarea, cli, [srv], str(ruta))
+    resultado_ruta, texto = email_utils.generar_archivo_msg(
+        tarea,
+        cli,
+        [srv],
+        str(ruta),
+        carrier,
+    )
     assert resultado_ruta == str(ruta)
     assert ruta.exists()
     assert "Mantenimiento" in texto
@@ -298,7 +304,13 @@ def test_generar_archivo_msg_win32(tmp_path, monkeypatch):
     )
 
     ruta = tmp_path / "aviso.msg"
-    resultado, texto = email_utils.generar_archivo_msg(tarea, cli, [srv], str(ruta))
+    resultado, texto = email_utils.generar_archivo_msg(
+        tarea,
+        cli,
+        [srv],
+        str(ruta),
+        carrier,
+    )
     assert resultado == str(ruta)
     assert outlook.saved == (str(ruta), 3)
     assert ruta.exists()


### PR DESCRIPTION
## Summary
- permitir que `generar_archivo_msg` reciba un `Carrier`
- propagar el objeto en `procesar_correo_a_tarea`
- reenviar avisos y registrar tareas usando el mismo carrier
- adaptar las pruebas de `email_utils`

## Testing
- `./setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eab6019508330be987d08f1bb41b6