### PR TITLE
Add MSG template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ El comportamiento de SandyBot se ajusta mediante varias variables de entorno:
 - `SLA_HISTORIAL_DIR`: carpeta donde se guardan las plantillas de SLA reemplazadas.
 
 - `SIGNATURE_PATH`: ruta a la firma opcional que se agregará en los correos.
+- `MSG_TEMPLATE_PATH`: plantilla para generar los avisos `.MSG`. Por defecto se
+  usa `templates/Plantilla Correo.MSG`.
 - `GPT_MODEL`: modelo de OpenAI a emplear. Por defecto se aplica `gpt-4`.
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`: datos para el servidor
   de correo saliente.
@@ -225,6 +227,12 @@ formatear el mensaje. Para leer los adjuntos es necesario instalar
 `extract-msg`; `pywin32` es opcional, pero permite crear un `.MSG`
 real con la firma incluida.
 Además Sandy envía el aviso por correo a los destinatarios configurados para el cliente o para el par (cliente, carrier) cuando corresponde.
+
+#### Plantilla para correos MSG
+
+La variable `MSG_TEMPLATE_PATH` define la base utilizada al crear estos avisos.
+Si no se especifica, se toma `templates/Plantilla Correo.MSG` dentro del
+proyecto. Este archivo se puede personalizar libremente y el bot reemplazará el marcador `{{CONTENIDO}}` por el cuerpo generado. Cuando Outlook no está disponible se lee la plantilla como texto plano.
 
 ### Reenviar un aviso de tarea
 

--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -90,6 +90,10 @@ class Config:  # pylint: disable=too-many-instance-attributes
 
         # 6) Firma de correos opcional
         self.SIGNATURE_PATH = os.getenv("SIGNATURE_PATH")
+        self.MSG_TEMPLATE_PATH = os.getenv(
+            "MSG_TEMPLATE_PATH",
+            str(self.BASE_DIR / "templates" / "Plantilla Correo.MSG"),
+        )
 
         # 7) GPT
         self.GPT_MODEL = os.getenv("GPT_MODEL", "gpt-4")
@@ -149,10 +153,16 @@ class Config:  # pylint: disable=too-many-instance-attributes
         opcionales = {
             "SLACK_WEBHOOK_URL": self.SLACK_WEBHOOK_URL,
             "SUPERVISOR_DB_ID": self.SUPERVISOR_DB_ID,
+            "MSG_TEMPLATE_PATH": self.MSG_TEMPLATE_PATH,
         }
         warn = [v for v, val in opcionales.items() if not val]
         if warn:
             logging.warning("Variables opcionales ausentes: %s", ", ".join(warn))
+
+        if self.MSG_TEMPLATE_PATH and not Path(self.MSG_TEMPLATE_PATH).exists():
+            logging.warning(
+                "Plantilla MSG no encontrada: %s", self.MSG_TEMPLATE_PATH
+            )
 
         email_faltantes = [
             n for n in ("SMTP_USER", "SMTP_PASSWORD", "EMAIL_FROM") if not getattr(self, n)


### PR DESCRIPTION
## Summary
- make MSG template path configurable in `config`
- read template when generating MSG files
- use template in text mode
- document `MSG_TEMPLATE_PATH`
- test generation with and without Outlook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ebc11348083309a674a217894e667