### PR TITLE
Simplificar flujo identificador

### DIFF
--- a/Sandy bot/sandybot/handlers/identificador_tarea.py
+++ b/Sandy bot/sandybot/handlers/identificador_tarea.py
@@ -13,11 +13,11 @@ from pathlib import Path
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from ..utils import obtener_mensaje
+from ..email_utils import procesar_correo_a_tarea
 from ..registrador import responder_registrando
+from ..utils import obtener_mensaje
 from .estado import UserState
 from .procesar_correos import _leer_msg
-from ..email_utils import procesar_correo_a_tarea
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +38,8 @@ async def iniciar_identificador_tarea(
         mensaje,
         user_id,
         "identificador_tarea",
-        "Adjuntá el correo .MSG con la tarea. "
-        "En el texto indicá el nombre del cliente y opcionalmente el carrier.",
+        "📎 Adjuntá el archivo *.MSG* del mantenimiento.\n"
+        "No hace falta escribir nada más, yo me encargo del resto 😉",
         "identificador_tarea",
     )
 
@@ -55,16 +55,7 @@ async def procesar_identificador_tarea(
 
     user_id = mensaje.from_user.id
     partes = (mensaje.text or "").split()
-    if not partes:
-        await responder_registrando(
-            mensaje,
-            user_id,
-            mensaje.document.file_name,
-            "Indicá cliente y opcionalmente carrier en el texto del mensaje.",
-            "identificador_tarea",
-        )
-        return
-    cliente = partes[0]
+    cliente = partes[0] if partes else "METROTEL"
     carrier = partes[1] if len(partes) > 1 else None
 
     archivo = await mensaje.document.get_file()

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -14,12 +14,11 @@ from pathlib import Path
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from ..utils import obtener_mensaje
-from ..email_utils import procesar_correo_a_tarea, enviar_correo
+from ..email_utils import enviar_correo, procesar_correo_a_tarea
 from ..registrador import responder_registrando
+from ..utils import obtener_mensaje
 
 logger = logging.getLogger(__name__)
-
 
 
 # ────────────────────────── UTILIDAD LOCAL ──────────────────────────
@@ -70,17 +69,7 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     user_id = update.effective_user.id
 
     # Sintaxis: /procesar_correos <cliente> [carrier]
-    if not context.args:
-        await responder_registrando(
-            mensaje,
-            user_id,
-            mensaje.text or getattr(mensaje.document, "file_name", ""),
-            "Usá: /procesar_correos <cliente> [carrier] y adjuntá los archivos.",
-            "tareas",
-        )
-        return
-
-    cliente_nombre = context.args[0]
+    cliente_nombre = context.args[0] if context.args else "METROTEL"
     carrier_nombre = context.args[1] if len(context.args) > 1 else None
 
     # Colectar documentos


### PR DESCRIPTION
## Summary
- mejorar el mensaje inicial al identificar una tarea
- asumir METROTEL como cliente por defecto
- permitir /procesar_correos sin argumentos

## Testing
- `pytest -q`
- `python -m sandybot.bot --check-env` *(falla por variables de entorno faltantes)*

------
https://chatgpt.com/codex/tasks/task_e_684f394f1f848330a74ff8b5e889fcc7