### PR TITLE
Simplificar flujo identificador

### DIFF
--- a/Sandy bot/sandybot/handlers/__init__.py
+++ b/Sandy bot/sandybot/handlers/__init__.py
@@ -5,63 +5,60 @@
 Handlers del bot Sandy
 """
 
-from .start import start_handler
 from .callback import callback_handler
-from .message import message_handler
-from .document import document_handler
-from .voice import voice_handler
-from .ingresos import iniciar_verificacion_ingresos, procesar_ingresos
-from .registro_ingresos import iniciar_registro_ingresos, guardar_registro
-from .repetitividad import procesar_repetitividad
-from .informe_sla import (
-    iniciar_informe_sla,
-    procesar_informe_sla,
-    actualizar_plantilla_sla,
+from .cargar_tracking import guardar_tracking_servicio, iniciar_carga_tracking
+from .carriers import (
+    actualizar_carrier,
+    agregar_carrier,
+    eliminar_carrier,
+    listar_carriers,
 )
-from .comparador import iniciar_comparador, recibir_tracking, procesar_comparacion
-from .cargar_tracking import iniciar_carga_tracking, guardar_tracking_servicio
-from .descargar_tracking import iniciar_descarga_tracking, enviar_tracking_servicio
-from .descargar_camaras import iniciar_descarga_camaras, enviar_camaras_servicio
-from .enviar_camaras_mail import (
-    iniciar_envio_camaras_mail,
-    procesar_envio_camaras_mail,
-)
-from .id_carrier import iniciar_identificador_carrier, procesar_identificador_carrier
-from .incidencias import iniciar_incidencias, procesar_incidencias
+from .comparador import iniciar_comparador, procesar_comparacion, recibir_tracking
+from .descargar_camaras import enviar_camaras_servicio, iniciar_descarga_camaras
+from .descargar_tracking import enviar_tracking_servicio, iniciar_descarga_tracking
 from .destinatarios import (
     agregar_destinatario,
     eliminar_destinatario,
     listar_destinatarios,
     listar_destinatarios_por_carrier,
 )
-from .carriers import (
-    listar_carriers,
-    agregar_carrier,
-    eliminar_carrier,
-    actualizar_carrier,
-)
-from .tarea_programada import registrar_tarea_programada
 from .detectar_tarea_mail import detectar_tarea_mail
-from .procesar_correos import procesar_correos
+from .document import document_handler
+from .enviar_camaras_mail import iniciar_envio_camaras_mail, procesar_envio_camaras_mail
+from .id_carrier import iniciar_identificador_carrier, procesar_identificador_carrier
 from .identificador_tarea import (
     iniciar_identificador_tarea,
     procesar_identificador_tarea,
 )
-from .reenviar_aviso import reenviar_aviso
+from .incidencias import iniciar_incidencias, procesar_incidencias
+from .informe_sla import (
+    actualizar_plantilla_sla,
+    iniciar_informe_sla,
+    procesar_informe_sla,
+)
+from .ingresar_tarea import ingresar_tarea
+from .ingresos import iniciar_verificacion_ingresos, procesar_ingresos
 from .listar_tareas import listar_tareas
+from .message import message_handler
+from .procesar_correos import procesar_correos
+from .reenviar_aviso import reenviar_aviso
+from .registro_ingresos import guardar_registro, iniciar_registro_ingresos
+from .repetitividad import procesar_repetitividad
+from .start import start_handler
+from .supermenu import depurar_duplicados, listar_camaras
+from .supermenu import listar_carriers as listar_carriers_cdb
 from .supermenu import (
-    supermenu,
-    listar_servicios,
-    listar_reclamos,
-    listar_camaras,
-    depurar_duplicados,
     listar_clientes,
-    listar_carriers as listar_carriers_cdb,
     listar_conversaciones,
     listar_ingresos,
+    listar_reclamos,
+    listar_servicios,
     listar_tareas_programadas,
     listar_tareas_servicio,
+    supermenu,
 )
+from .tarea_programada import registrar_tarea_programada
+from .voice import voice_handler
 
 __all__ = [
     "start_handler",
@@ -103,6 +100,7 @@ __all__ = [
     "listar_carriers",
     "actualizar_carrier",
     "registrar_tarea_programada",
+    "ingresar_tarea",
     "listar_tareas",
     "detectar_tarea_mail",
     "procesar_correos",

--- a/Sandy bot/sandybot/handlers/identificador_tarea.py
+++ b/Sandy bot/sandybot/handlers/identificador_tarea.py
@@ -13,11 +13,11 @@ from pathlib import Path
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from ..utils import obtener_mensaje
+from ..email_utils import procesar_correo_a_tarea
 from ..registrador import responder_registrando
+from ..utils import obtener_mensaje
 from .estado import UserState
 from .procesar_correos import _leer_msg
-from ..email_utils import procesar_correo_a_tarea
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +38,8 @@ async def iniciar_identificador_tarea(
         mensaje,
         user_id,
         "identificador_tarea",
-        "Adjuntá el correo .MSG con la tarea. "
-        "En el texto indicá el nombre del cliente y opcionalmente el carrier.",
+        "📎 Adjuntá el archivo *.MSG* del mantenimiento.\n"
+        "No hace falta escribir nada más, yo me encargo del resto 😉",
         "identificador_tarea",
     )
 
@@ -55,16 +55,7 @@ async def procesar_identificador_tarea(
 
     user_id = mensaje.from_user.id
     partes = (mensaje.text or "").split()
-    if not partes:
-        await responder_registrando(
-            mensaje,
-            user_id,
-            mensaje.document.file_name,
-            "Indicá cliente y opcionalmente carrier en el texto del mensaje.",
-            "identificador_tarea",
-        )
-        return
-    cliente = partes[0]
+    cliente = partes[0] if partes else "METROTEL"
     carrier = partes[1] if len(partes) > 1 else None
 
     archivo = await mensaje.document.get_file()
@@ -88,6 +79,18 @@ async def procesar_identificador_tarea(
         tarea, cliente_obj, ruta_msg, _ = await procesar_correo_a_tarea(
             contenido, cliente, carrier
         )
+    except ValueError as exc:
+        logger.error("Fallo identificando tarea: %s", exc)
+        await responder_registrando(
+            mensaje,
+            user_id,
+            mensaje.document.file_name,
+            "No pude identificar la tarea en el correo. Podés cargarla "
+            "manualmente con /ingresar_tarea",
+            "identificador_tarea",
+        )
+        os.remove(ruta)
+        return
     except Exception as exc:  # pragma: no cover
         logger.error("Fallo identificando tarea: %s", exc)
         await responder_registrando(

--- a/Sandy bot/sandybot/handlers/ingresar_tarea.py
+++ b/Sandy bot/sandybot/handlers/ingresar_tarea.py
@@ -1,0 +1,13 @@
+# Nombre de archivo: ingresar_tarea.py
+# Ubicación de archivo: Sandy bot/sandybot/handlers/ingresar_tarea.py
+# User-provided custom instructions
+"""Ingreso manual de tareas programadas."""
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from .tarea_programada import registrar_tarea_programada
+
+
+async def ingresar_tarea(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Alias simplificado a :func:`registrar_tarea_programada`."""
+    await registrar_tarea_programada(update, context)

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -14,12 +14,11 @@ from pathlib import Path
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from ..utils import obtener_mensaje
-from ..email_utils import procesar_correo_a_tarea, enviar_correo
+from ..email_utils import enviar_correo, procesar_correo_a_tarea
 from ..registrador import responder_registrando
+from ..utils import obtener_mensaje
 
 logger = logging.getLogger(__name__)
-
 
 
 # ────────────────────────── UTILIDAD LOCAL ──────────────────────────
@@ -70,17 +69,7 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     user_id = update.effective_user.id
 
     # Sintaxis: /procesar_correos <cliente> [carrier]
-    if not context.args:
-        await responder_registrando(
-            mensaje,
-            user_id,
-            mensaje.text or getattr(mensaje.document, "file_name", ""),
-            "Usá: /procesar_correos <cliente> [carrier] y adjuntá los archivos.",
-            "tareas",
-        )
-        return
-
-    cliente_nombre = context.args[0]
+    cliente_nombre = context.args[0] if context.args else "METROTEL"
     carrier_nombre = context.args[1] if len(context.args) > 1 else None
 
     # Colectar documentos


### PR DESCRIPTION
## Summary
- mejorar el mensaje inicial al identificar una tarea
- asumir METROTEL como cliente por defecto
- permitir /procesar_correos sin argumentos
- fallback regex y extracción segura en `email_utils`
- manejar fallas con aviso de ingreso manual y stub `/ingresar_tarea`
- cubrir caso donde GPT devuelve texto antes del JSON

## Testing
- `pytest -q`
- `PYTHONPATH='Sandy bot' python -m sandybot.bot --check-env` *(falla por variables de entorno faltantes)*

------
https://chatgpt.com/codex/tasks/task_e_684f394f1f848330a74ff8b5e889fcc7