### PR TITLE
Implementar registro de tareas sin servicios

### DIFF
--- a/Sandy bot/sandybot/handlers/identificador_tarea.py
+++ b/Sandy bot/sandybot/handlers/identificador_tarea.py
@@ -115,7 +115,7 @@ async def procesar_identificador_tarea(
         mensaje,
         user_id,
         mensaje.document.file_name,
-        f"Tarea {tarea.id} registrada para {cliente_obj.nombre}.",
+        f"✅ Tarea Registrada ID: {tarea.id}",
         "identificador_tarea",
     )
     UserState.set_mode(user_id, "")

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -40,10 +40,11 @@ def _leer_msg(ruta: str) -> str:
 
         msg = extract_msg.Message(ruta)
         asunto = msg.subject or ""
+        remitente = getattr(msg, "sender", None) or getattr(msg, "sender_email", None)
+        remitente_nom = getattr(msg, "sender_name", None)
 
         # 👉 1A) Usamos .body y, si está vacío, htmlBody o rtfBody
         cuerpo = msg.body or getattr(msg, "htmlBody", "") or getattr(msg, "rtfBody", "")
-
 
         # Si viene como bytes convertimos a texto para evitar errores
         if isinstance(cuerpo, bytes):
@@ -57,7 +58,6 @@ def _leer_msg(ruta: str) -> str:
             except Exception:
                 asunto = asunto.decode("latin-1", "ignore")
 
-
         # 👉 1B) Convertimos HTML a texto si es necesario
         if "<html" in cuerpo.lower():
             try:
@@ -68,7 +68,12 @@ def _leer_msg(ruta: str) -> str:
                 logger.warning("beautifulsoup4 no instalado; continúo con HTML crudo")
         cuerpo = cuerpo.strip()
 
-        texto = f"{asunto}\n{cuerpo}".strip()
+        encabezado = []
+        if remitente:
+            encabezado.append(f"From: {remitente}")
+        if remitente_nom:
+            encabezado.append(f"Name: {remitente_nom}")
+        texto = "\n".join(encabezado + [asunto, cuerpo]).strip()
 
         if not texto:
             try:

--- a/tests/data/telxius.msg
+++ b/tests/data/telxius.msg
@@ -1,0 +1,4 @@
+Inicio: 16/06/2025 11:00
+Fin: 16/06/2025 12:00
+ID interno: SWX0030940
+Servicios afectados: CRT-008785

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -457,11 +457,10 @@ def test_procesar_correo_sin_servicios(monkeypatch, caplog):
 
     email_utils.gpt = GPTStub()
 
-    with caplog.at_level(logging.WARNING):
-        with pytest.raises(ValueError) as err:
-            asyncio.run(email_utils.procesar_correo_a_tarea("correo", "Cli"))
-        assert "Faltantes: 99999" in caplog.text
-    assert "99999" in str(err.value)
+    tarea, _, _, _ = asyncio.run(email_utils.procesar_correo_a_tarea("correo", "Cli"))
+    with bd.SessionLocal() as s:
+        pendiente = s.query(bd.ServicioPendiente).filter_by(tarea_id=tarea.id).first()
+    assert pendiente.id_carrier == "99999"
 
 
 def test_procesar_correo_respuesta_con_texto(monkeypatch):

--- a/tests/test_identificador_tarea.py
+++ b/tests/test_identificador_tarea.py
@@ -1,23 +1,32 @@
 # Nombre de archivo: test_identificador_tarea.py
 # Ubicación de archivo: tests/test_identificador_tarea.py
 # User-provided custom instructions
-import sys
-import importlib
 import asyncio
-from types import ModuleType, SimpleNamespace
-from pathlib import Path
-from sqlalchemy.orm import sessionmaker
+import importlib
+import sys
 import tempfile
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+from sqlalchemy.orm import sessionmaker
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 
-from tests.telegram_stub import Message, Update, Document
+from tests.telegram_stub import Document, Message, Update
 
 # Stubs de openai y jsonschema
 openai_stub = ModuleType("openai")
+
+
 class AsyncOpenAI:
     def __init__(self, api_key=None):
-        self.chat = type("c", (), {"completions": type("comp", (), {"create": lambda *a, **k: None})()})()
+        self.chat = type(
+            "c",
+            (),
+            {"completions": type("comp", (), {"create": lambda *a, **k: None})()},
+        )()
+
+
 openai_stub.AsyncOpenAI = AsyncOpenAI
 sys.modules.setdefault("openai", openai_stub)
 
@@ -41,9 +50,11 @@ sys.modules.setdefault("extract_msg", extract_stub)
 
 # Base de datos en memoria
 import sqlalchemy
+
 orig_engine = sqlalchemy.create_engine
 sqlalchemy.create_engine = lambda *a, **k: orig_engine("sqlite:///:memory:")
 import sandybot.database as bd
+
 sqlalchemy.create_engine = orig_engine
 bd.SessionLocal = sessionmaker(bind=bd.engine, expire_on_commit=False)
 bd.Base.metadata.create_all(bind=bd.engine)
@@ -75,12 +86,14 @@ def test_identificador_tarea(tmp_path):
     servicio = bd.crear_servicio(nombre="Srv", cliente="Cli")
 
     import sandybot.email_utils as email_utils
+
     class GPTStub(email_utils.gpt.__class__):
         async def consultar_gpt(self, mensaje: str, cache: bool = True) -> str:
             return (
                 '{"inicio": "2024-01-02T08:00:00", "fin": "2024-01-02T10:00:00", '
-                '"tipo": "Mant", "afectacion": "1h", "ids": [' + str(servicio.id) + ']}'
+                '"tipo": "Mant", "afectacion": "1h", "ids": [' + str(servicio.id) + "]}"
             )
+
     email_utils.gpt = GPTStub()
 
     doc = Document(file_name="aviso.msg", content="dummy")
@@ -144,11 +157,12 @@ def test_identificador_tarea_heuristicas(tmp_path):
         async def consultar_gpt(self, mensaje: str, cache: bool = True) -> str:
             return (
                 '{"inicio": "02/01 08:00", "fin": "02/01 10:00", '
-                '"tipo": "Mant", "afectacion": "1h", "ids": [' + str(servicio.id) + ']}'
+                '"tipo": "Mant", "afectacion": "1h", "ids": [' + str(servicio.id) + "]}"
             )
 
         async def procesar_json_response(self, resp, esquema):
             import json
+
             return json.loads(resp)
 
     email_utils.gpt = GPTStub()
@@ -171,10 +185,58 @@ def test_identificador_tarea_heuristicas(tmp_path):
     asyncio.run(mod.procesar_identificador_tarea(update, ctx))
 
     with bd.SessionLocal() as s:
-        tarea = s.query(bd.TareaProgramada).order_by(bd.TareaProgramada.id.desc()).first()
+        tarea = (
+            s.query(bd.TareaProgramada).order_by(bd.TareaProgramada.id.desc()).first()
+        )
         srv = s.get(bd.Servicio, servicio.id)
 
     tempfile.gettempdir = orig_tmp
 
     assert tarea.id == prev_tareas + 1
     assert srv.carrier_id is not None
+
+
+def test_identificador_tarea_telxius(tmp_path):
+    """Caso real con servicio faltante."""
+
+    global TEMP_DIR
+    TEMP_DIR = tmp_path
+    orig_tmp = tempfile.gettempdir
+    tempfile.gettempdir = lambda: str(TEMP_DIR)
+
+    class MsgTelxius:
+        def __init__(self, path):
+            self.body = Path(path).read_text()
+            self.subject = "TELXIUS - METROTEL - EMERGENCY"
+            self.sender = "noc@telxius.com"
+            self.sender_name = "Telxius"
+
+    extract_stub.Message = MsgTelxius
+
+    pkg = "sandybot.handlers"
+    mod_name = f"{pkg}.identificador_tarea"
+    spec = importlib.util.spec_from_file_location(
+        mod_name,
+        ROOT_DIR / "Sandy bot" / "sandybot" / "handlers" / "identificador_tarea.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+
+    archivo = ROOT_DIR / "tests" / "data" / "telxius.msg"
+    doc = Document(file_name="telxius.msg", content=archivo.read_text())
+    msg = Message("Cli", document=doc)
+    update = Update(message=msg)
+    ctx = SimpleNamespace(args=[], user_data={})
+
+    asyncio.run(mod.procesar_identificador_tarea(update, ctx))
+
+    with bd.SessionLocal() as s:
+        tarea = (
+            s.query(bd.TareaProgramada).order_by(bd.TareaProgramada.id.desc()).first()
+        )
+        pendiente = s.query(bd.ServicioPendiente).filter_by(tarea_id=tarea.id).first()
+
+    tempfile.gettempdir = orig_tmp
+
+    assert pendiente.id_carrier == "CRT-008785"


### PR DESCRIPTION
## Notas
- Se agregó el campo `id_interno` a `TareaProgramada` y la tabla `ServicioPendiente` para rastrear tokens no asociados.
- `email_utils.procesar_correo_a_tarea` extrae datos básicos con `_detectar_datos_correo`, registra tareas aunque no se encuentren servicios y crea `ServicioPendiente`.
- `_leer_msg` ahora incluye remitente y nombre para detectar el carrier.
- El handler `identificador_tarea` envía la confirmación solicitada.
- Se incluyó un ejemplo real en `tests/data/telxius.msg` y se actualizaron las pruebas.

------
https://chatgpt.com/codex/tasks/task_e_685036b7faec8330b83a883b7d62553d