### PR TITLE
Eliminar duplicados al crear restricción

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -234,6 +234,35 @@ class ServicioPendiente(Base):
     id_carrier = Column(String, index=True)
 
 
+def eliminar_duplicados_tareas(conn) -> None:
+    """Borra tareas con ``carrier_id`` e ``id_interno`` repetidos.
+
+    Solo se conserva la fila con menor ``id`` de cada par duplicado para
+    permitir la creación de la restricción única.
+    """
+
+    filas = conn.execute(
+        text(
+            """
+            SELECT carrier_id, id_interno, MIN(id) AS keep_id
+            FROM tareas_programadas
+            WHERE carrier_id IS NOT NULL AND id_interno IS NOT NULL
+            GROUP BY carrier_id, id_interno
+            HAVING COUNT(*) > 1
+            """
+        )
+    ).fetchall()
+
+    for carrier_id, id_interno, keep_id in filas:
+        conn.execute(
+            text(
+                "DELETE FROM tareas_programadas "
+                "WHERE carrier_id = :c AND id_interno = :i AND id <> :k"
+            ),
+            {"c": carrier_id, "i": id_interno, "k": keep_id},
+        )
+
+
 def ensure_servicio_columns() -> None:
     """Comprueba que la tabla ``servicios`` posea todas las columnas del modelo.
 
@@ -350,6 +379,7 @@ def ensure_servicio_columns() -> None:
     }
     if "uix_carrier_interno" not in uniques_tarea:
         with engine.begin() as conn:
+            eliminar_duplicados_tareas(conn)
             conn.execute(
                 text(
                     "ALTER TABLE tareas_programadas ADD CONSTRAINT uix_carrier_interno UNIQUE (carrier_id, id_interno)"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -376,3 +376,46 @@ def test_camara_unica():
         filas = s.query(bd.Camara).filter(bd.Camara.id_servicio == srv.id).all()
     assert len(filas) == 1
     assert c1.id == c2.id
+
+
+import pytest
+
+
+@pytest.mark.skipif(bd.engine.dialect.name == "sqlite", reason="solo postgres")
+def test_eliminar_duplicados_tareas():
+    """``ensure_servicio_columns`` borra tareas repetidas."""
+
+    bd.Base.metadata.create_all(bind=bd.engine)
+    with bd.engine.begin() as conn:
+        conn.execute(text("DROP TABLE tareas_programadas"))
+        conn.execute(
+            text(
+                "CREATE TABLE tareas_programadas ("
+                "id INTEGER PRIMARY KEY, "
+                "fecha_inicio DATETIME, "
+                "fecha_fin DATETIME, "
+                "tipo_tarea STRING, "
+                "tiempo_afectacion STRING, "
+                "descripcion STRING, "
+                "carrier_id INTEGER, "
+                "id_interno STRING)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO tareas_programadas "
+                "(id, fecha_inicio, fecha_fin, tipo_tarea, carrier_id, id_interno) VALUES "
+                "(1, '2024-01-01 00:00', '2024-01-01 01:00', 'M', 1, 'X1'),"
+                "(2, '2024-01-02 00:00', '2024-01-02 01:00', 'M', 1, 'X1')"
+            )
+        )
+
+    bd.ensure_servicio_columns()
+
+    with bd.SessionLocal() as s:
+        filas = (
+            s.query(bd.TareaProgramada)
+            .filter(bd.TareaProgramada.carrier_id == 1, bd.TareaProgramada.id_interno == "X1")
+            .all()
+        )
+    assert len(filas) == 1


### PR DESCRIPTION
## Summary
- eliminar registros repetidos de `tareas_programadas`
- probar la limpieza automática antes de crear la restricción

## Testing
- `./setup_env.sh`
- `source .venv/bin/activate`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6850734e4d04833098540b3f6e1290f2