### PR TITLE
Eliminar duplicados al crear restricción

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -234,6 +234,58 @@ class ServicioPendiente(Base):
     id_carrier = Column(String, index=True)
 
 
+def eliminar_duplicados_tareas(conn) -> None:
+    """Borra tareas con ``carrier_id`` e ``id_interno`` repetidos.
+
+    Solo se conserva la fila con menor ``id`` de cada par duplicado para
+    permitir la creación de la restricción única.
+    """
+
+    filas = conn.execute(
+        text(
+            """
+            SELECT carrier_id, id_interno, MIN(id) AS keep_id
+            FROM tareas_programadas
+            WHERE carrier_id IS NOT NULL AND id_interno IS NOT NULL
+            GROUP BY carrier_id, id_interno
+            HAVING COUNT(*) > 1
+            """
+        )
+    ).fetchall()
+
+    inspector = inspect(conn)
+    tablas = set(inspector.get_table_names())
+
+    for carrier_id, id_interno, keep_id in filas:
+        dup_ids = conn.execute(
+            text(
+                "SELECT id FROM tareas_programadas "
+                "WHERE carrier_id = :c AND id_interno = :i AND id <> :k"
+            ),
+            {"c": carrier_id, "i": id_interno, "k": keep_id},
+        ).fetchall()
+
+        for (dup_id,) in dup_ids:
+            if "tareas_servicio" in tablas:
+                conn.execute(
+                    text(
+                        "UPDATE tareas_servicio SET tarea_id = :k WHERE tarea_id = :d"
+                    ),
+                    {"k": keep_id, "d": dup_id},
+                )
+            if "servicios_pendientes" in tablas:
+                conn.execute(
+                    text(
+                        "UPDATE servicios_pendientes SET tarea_id = :k WHERE tarea_id = :d"
+                    ),
+                    {"k": keep_id, "d": dup_id},
+                )
+            conn.execute(
+                text("DELETE FROM tareas_programadas WHERE id = :d"),
+                {"d": dup_id},
+            )
+
+
 def ensure_servicio_columns() -> None:
     """Comprueba que la tabla ``servicios`` posea todas las columnas del modelo.
 
@@ -350,6 +402,7 @@ def ensure_servicio_columns() -> None:
     }
     if "uix_carrier_interno" not in uniques_tarea:
         with engine.begin() as conn:
+            eliminar_duplicados_tareas(conn)
             conn.execute(
                 text(
                     "ALTER TABLE tareas_programadas ADD CONSTRAINT uix_carrier_interno UNIQUE (carrier_id, id_interno)"


### PR DESCRIPTION
## Summary
- eliminar registros repetidos de `tareas_programadas`
- probar la limpieza automática antes de crear la restricción
- actualizar referencias en tablas relacionadas

## Testing
- `./setup_env.sh`
- `source .venv/bin/activate && pytest -k eliminar_duplicados_tareas -vv`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6850734e4d04833098540b3f6e1290f2