### PR TITLE
Implementar flag creada_nueva y mensaje de duplicados

### DIFF
--- a/Sandy bot/sandybot/email_utils.py
+++ b/Sandy bot/sandybot/email_utils.py
@@ -438,13 +438,13 @@ async def procesar_correo_a_tarea(
     *,
     generar_msg: bool = False,
 ) -> (
-    tuple[TareaProgramada, list[str]]
-    | tuple[TareaProgramada, Cliente, Path, str, list[str]]
+    tuple[TareaProgramada, bool, list[str]]
+    | tuple[TareaProgramada, bool, Cliente, Path, str, list[str]]
 ):
     """Analiza el correo y registra la tarea programada.
 
     Si ``generar_msg`` es ``True`` también se crea un archivo ``.MSG``. El
-    retorno incluye la tarea creada y los IDs pendientes.
+    retorno incluye la tarea, un flag ``creada_nueva`` y los IDs pendientes.
     """
 
     texto_limpio = _limpiar_correo(texto)
@@ -639,7 +639,7 @@ async def procesar_correo_a_tarea(
         if ids_pendientes:
             logger.info(">> Servicios faltantes: %s", ids_pendientes)
 
-        tarea = crear_tarea_programada(
+        tarea, creada_nueva = crear_tarea_programada(
             inicio,
             fin,
             tipo,
@@ -673,9 +673,9 @@ async def procesar_correo_a_tarea(
             )
             ruta_msg = Path(ruta_str)
 
-            return tarea, cliente, ruta_msg, cuerpo, ids_pendientes
+            return tarea, creada_nueva, cliente, ruta_msg, cuerpo, ids_pendientes
 
-        return tarea, ids_pendientes
+        return tarea, creada_nueva, ids_pendientes
 
 
 def _extraer_por_regex(texto: str) -> dict | None:

--- a/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
+++ b/Sandy bot/sandybot/handlers/detectar_tarea_mail.py
@@ -91,6 +91,7 @@ async def detectar_tarea_mail(
     try:
         (
             tarea,
+            creada_nueva,
             cliente,
             ruta,
             _,
@@ -126,10 +127,17 @@ async def detectar_tarea_mail(
         with open(ruta, "rb") as f:
             await mensaje.reply_document(f, filename=ruta.name)
 
+    detalle = (
+        f"✅ Tarea {tarea.id} registrada."
+        if creada_nueva
+        else f"🔄 La tarea {tarea.id_interno or 'N/D'} ya existía (ID BD: {tarea.id})."
+    )
+    if tarea.id_interno:
+        detalle += f"\nID Carrier: {tarea.id_interno}"
     await responder_registrando(
         mensaje,
         user_id,
         mensaje.text or getattr(mensaje.document, "file_name", ""),
-        f"Tarea {tarea.id} registrada.",
+        detalle,
         "tareas",
     )

--- a/Sandy bot/sandybot/handlers/identificador_tarea.py
+++ b/Sandy bot/sandybot/handlers/identificador_tarea.py
@@ -76,7 +76,7 @@ async def procesar_identificador_tarea(
             os.remove(ruta)
             return
 
-        tarea, ids_pendientes = await procesar_correo_a_tarea(
+        tarea, creada_nueva, ids_pendientes = await procesar_correo_a_tarea(
             contenido, cliente, carrier, generar_msg=False
         )
     except ValueError as exc:
@@ -108,7 +108,7 @@ async def procesar_identificador_tarea(
     carrier_nombre = "Sin carrier"
     servicios_txt = ""
     if tarea.carrier_id:
-        from ..database import Carrier, SessionLocal, TareaServicio
+        from ..database import Carrier, Servicio, SessionLocal, TareaServicio
 
         with SessionLocal() as s:
             car = s.get(Carrier, tarea.carrier_id)
@@ -129,8 +129,14 @@ async def procesar_identificador_tarea(
                     servicios_pares.append(f"{propio} , {car}")
             servicios_txt = "; ".join(servicios_pares)
 
-    detalle = (
-        f"✅ *Tarea Registrada ID: {tarea.id}*\n"
+    if creada_nueva:
+        detalle = f"✅ *Tarea Registrada ID: {tarea.id}*\n"
+    else:
+        interno = tarea.id_interno or "N/D"
+        detalle = f"🔄 La tarea {interno} ya estaba registrada (ID BD: {tarea.id})\n"
+
+    detalle += (
+        f"ID Carrier: {tarea.id_interno or 'N/D'}\n"
         f"• Carrier: {carrier_nombre}\n"
         f"• Tipo   : {tarea.tipo_tarea}\n"
         f"• Inicio : {tarea.fecha_inicio} UTC-3\n"

--- a/Sandy bot/sandybot/handlers/procesar_correos.py
+++ b/Sandy bot/sandybot/handlers/procesar_correos.py
@@ -139,6 +139,7 @@ async def procesar_correos(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             # Procesar correo → registrar tarea → generar .msg final
             (
                 tarea,
+                _creada_nueva,
                 cliente,
                 ruta_msg,
                 cuerpo,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -212,7 +212,7 @@ def test_cliente_destinatarios():
 
 def test_crear_tarea_y_relacion():
     s = bd.crear_servicio(nombre="Srv", cliente="Cli")
-    tarea = bd.crear_tarea_programada(
+    tarea, _ = bd.crear_tarea_programada(
         datetime(2024, 1, 1, 8),
         datetime(2024, 1, 1, 10),
         "Mantenimiento",
@@ -232,7 +232,7 @@ def test_carrier_asociaciones():
         s.refresh(car)
 
     srv = bd.crear_servicio(nombre="SrvC", cliente="CliC", carrier_id=car.id)
-    tarea = bd.crear_tarea_programada(
+    tarea, _ = bd.crear_tarea_programada(
         datetime(2024, 1, 3, 8),
         datetime(2024, 1, 3, 10),
         "Mant",
@@ -275,7 +275,7 @@ def test_ensure_servicio_columns_indice_tarea_programada():
 def test_tarea_servicio_unica():
     """La relación tarea-servicio no debe duplicarse (restricción única)."""
     s = bd.crear_servicio(nombre="SrvU", cliente="CliU")
-    tarea = bd.crear_tarea_programada(
+    tarea, _ = bd.crear_tarea_programada(
         datetime(2024, 1, 2, 8),
         datetime(2024, 1, 2, 10),
         "Mantenimiento",
@@ -292,7 +292,7 @@ def test_tarea_servicio_unica():
 def test_crear_tarea_varios_servicios():
     s1 = bd.crear_servicio(nombre="Sv1", cliente="C1")
     s2 = bd.crear_servicio(nombre="Sv2", cliente="C2")
-    tarea = bd.crear_tarea_programada(
+    tarea, _ = bd.crear_tarea_programada(
         datetime(2024, 1, 3, 8),
         datetime(2024, 1, 3, 10),
         "Mantenimiento",
@@ -312,7 +312,7 @@ def test_crear_tarea_servicio_repetido():
     """Ignora servicios repetidos al crear la tarea."""
     s = bd.crear_servicio(nombre="SvRep", cliente="CliR")
 
-    tarea = bd.crear_tarea_programada(
+    tarea, _ = bd.crear_tarea_programada(
         datetime(2024, 1, 4, 8),
         datetime(2024, 1, 4, 10),
         "Mantenimiento",
@@ -416,13 +416,15 @@ def test_eliminar_duplicados_tareas():
             )
         )
 
-
     bd.ensure_servicio_columns()
 
     with bd.SessionLocal() as s:
         filas = (
             s.query(bd.TareaProgramada)
-            .filter(bd.TareaProgramada.carrier_id == 1, bd.TareaProgramada.id_interno == "X1")
+            .filter(
+                bd.TareaProgramada.carrier_id == 1,
+                bd.TareaProgramada.id_interno == "X1",
+            )
             .all()
         )
         pendiente = s.query(bd.ServicioPendiente).first()

--- a/tests/test_detectar_tarea_mail.py
+++ b/tests/test_detectar_tarea_mail.py
@@ -153,7 +153,14 @@ def test_cuerpo_sin_carrier(tmp_path):
         capturado["texto"] = texto
         ruta = tmp_path / "dummy.msg"
         ruta.write_text("x")
-        return SimpleNamespace(id=1), SimpleNamespace(nombre=cliente), ruta, "ok"
+        return (
+            SimpleNamespace(id=1, id_interno="ID001"),
+            True,
+            SimpleNamespace(nombre=cliente),
+            ruta,
+            "ok",
+            [],
+        )
 
     email_utils.procesar_correo_a_tarea = stub_procesar
     tarea_mod.procesar_correo_a_tarea = stub_procesar

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -170,6 +170,7 @@ def test_procesar_correo_fecha_dia_mes(tmp_path):
     bd.crear_servicio(nombre="Srv1", cliente="Cli", id_servicio=1)
     (
         tarea,
+        _creada,
         _,
         ruta,
         _,
@@ -234,7 +235,7 @@ def test_generar_archivo_msg(tmp_path):
     srv = bd.crear_servicio(
         nombre="S1", cliente="AcmeWin", cliente_id=cli.id, carrier_id=carrier.id
     )
-    tarea = bd.crear_tarea_programada(
+    tarea, _ = bd.crear_tarea_programada(
         datetime(2024, 1, 2, 8),
         datetime(2024, 1, 2, 10),
         "Mantenimiento",
@@ -276,7 +277,7 @@ def test_generar_archivo_msg_con_template(tmp_path, monkeypatch):
         s.refresh(cli)
 
     srv = bd.crear_servicio(nombre="S1", cliente="AcmeT", cliente_id=cli.id)
-    tarea = bd.crear_tarea_programada(
+    tarea, _ = bd.crear_tarea_programada(
         datetime(2024, 1, 2, 8),
         datetime(2024, 1, 2, 10),
         "Mantenimiento",
@@ -352,7 +353,7 @@ def test_generar_archivo_msg_win32(tmp_path, monkeypatch):
     srv = bd.crear_servicio(
         nombre="S1", cliente="AcmeWin2", cliente_id=cli.id, carrier_id=carrier.id
     )
-    tarea = bd.crear_tarea_programada(
+    tarea, _ = bd.crear_tarea_programada(
         datetime(2024, 1, 2, 8),
         datetime(2024, 1, 2, 10),
         "Mantenimiento",
@@ -428,7 +429,7 @@ def test_generar_archivo_msg_win32_template(tmp_path, monkeypatch):
         s.refresh(cli)
 
     srv = bd.crear_servicio(nombre="S1", cliente="AcmePlant", cliente_id=cli.id)
-    tarea = bd.crear_tarea_programada(
+    tarea, _ = bd.crear_tarea_programada(
         datetime(2024, 1, 2, 8),
         datetime(2024, 1, 2, 10),
         "Mant",
@@ -465,7 +466,7 @@ def test_procesar_correo_sin_servicios(monkeypatch, caplog):
 
     email_utils.gpt = GPTStub()
 
-    tarea, ids_pend = asyncio.run(
+    tarea, _creada, ids_pend = asyncio.run(
         email_utils.procesar_correo_a_tarea("correo", "Cli", generar_msg=False)
     )
     with bd.SessionLocal() as s:
@@ -495,6 +496,7 @@ def test_procesar_correo_respuesta_con_texto(monkeypatch):
 
     (
         tarea,
+        _creada,
         _,
         _,
         _,
@@ -526,6 +528,7 @@ def test_procesar_correo_id_con_prefijo(monkeypatch):
 
     (
         tarea,
+        _creada,
         _,
         _,
         _,

--- a/tests/test_proxima_tarea.py
+++ b/tests/test_proxima_tarea.py
@@ -1,22 +1,25 @@
 # Nombre de archivo: test_proxima_tarea.py
 # Ubicación de archivo: tests/test_proxima_tarea.py
 # User-provided custom instructions
-import sys
 import importlib
-from types import ModuleType
-from pathlib import Path
+import sys
 from datetime import datetime, timedelta
+from pathlib import Path
+from types import ModuleType
+
 from sqlalchemy.orm import sessionmaker
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 
+import sqlalchemy
+
 # Registrar stubs básicos de telegram
 from tests.telegram_stub import Message, Update
 
-import sqlalchemy
 orig_engine = sqlalchemy.create_engine
 sqlalchemy.create_engine = lambda *a, **k: orig_engine("sqlite:///:memory:")
 import sandybot.database as bd
+
 sqlalchemy.create_engine = orig_engine
 bd.SessionLocal = sessionmaker(bind=bd.engine, expire_on_commit=False)
 bd.Base.metadata.create_all(bind=bd.engine)
@@ -29,9 +32,14 @@ def teardown_module(module):
 def test_obtener_proxima_tarea():
     srv = bd.crear_servicio(nombre="Srv", cliente="A")
     ahora = datetime.utcnow()
-    bd.crear_tarea_programada(ahora - timedelta(hours=2), ahora - timedelta(hours=1), "Pasada", [srv.id])
-    t2 = bd.crear_tarea_programada(ahora + timedelta(hours=1), ahora + timedelta(hours=2), "Siguiente", [srv.id])
-    bd.crear_tarea_programada(ahora + timedelta(hours=3), ahora + timedelta(hours=4), "Lejana", [srv.id])
+    bd.crear_tarea_programada(
+        ahora - timedelta(hours=2), ahora - timedelta(hours=1), "Pasada", [srv.id]
+    )[0]
+    t2, _ = bd.crear_tarea_programada(
+        ahora + timedelta(hours=1), ahora + timedelta(hours=2), "Siguiente", [srv.id]
+    )
+    bd.crear_tarea_programada(
+        ahora + timedelta(hours=3), ahora + timedelta(hours=4), "Lejana", [srv.id]
+    )[0]
     proxima = bd.obtener_proxima_tarea()
     assert proxima.id == t2.id
-

--- a/tests/test_supermenu.py
+++ b/tests/test_supermenu.py
@@ -1,32 +1,40 @@
 # Nombre de archivo: test_supermenu.py
 # Ubicación de archivo: tests/test_supermenu.py
 # User-provided custom instructions
-import sys
-import importlib
 import asyncio
+import importlib
+import sys
 from datetime import datetime
-from types import ModuleType, SimpleNamespace
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
 from sqlalchemy.orm import sessionmaker
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 
+import sqlalchemy
+
 from tests.telegram_stub import Message, Update
+
 # Variables mínimas configuradas en la fixture global
 
-import sqlalchemy
 orig_engine = sqlalchemy.create_engine
 sqlalchemy.create_engine = lambda *a, **k: orig_engine("sqlite:///:memory:")
 import sandybot.database as bd
+
 sqlalchemy.create_engine = orig_engine
 bd.SessionLocal = sessionmaker(bind=bd.engine, expire_on_commit=False)
 bd.Base.metadata.create_all(bind=bd.engine)
 
 captura = {}
 registrador_stub = ModuleType("sandybot.registrador")
+
+
 async def responder_registrando(*a, **k):
     captura["texto"] = a[3]
     captura["markup"] = k.get("reply_markup")
+
+
 registrador_stub.responder_registrando = responder_registrando
 registrador_stub.registrar_conversacion = lambda *a, **k: None
 sys.modules["sandybot.registrador"] = registrador_stub
@@ -40,11 +48,14 @@ def _importar():
         sys.modules[pkg] = handlers_pkg
     mod_name = f"{pkg}.supermenu"
     sys.modules["sandybot.registrador"] = registrador_stub
-    spec = importlib.util.spec_from_file_location(mod_name, ROOT_DIR / "Sandy bot" / "sandybot" / "handlers" / "supermenu.py")
+    spec = importlib.util.spec_from_file_location(
+        mod_name, ROOT_DIR / "Sandy bot" / "sandybot" / "handlers" / "supermenu.py"
+    )
     mod = importlib.util.module_from_spec(spec)
     sys.modules[mod_name] = mod
     spec.loader.exec_module(mod)
     return mod
+
 
 async def _run(func, args):
     mod = _importar()
@@ -82,11 +93,20 @@ def test_listar_descendente():
     bd.crear_camara("C1", s1.id)
     bd.crear_camara("C2", s2.id)
     texto_serv = asyncio.run(_run("listar_servicios", []))["texto"]
-    assert texto_serv.splitlines()[1].startswith("1. ") and str(s2.id) in texto_serv.splitlines()[1]
+    assert (
+        texto_serv.splitlines()[1].startswith("1. ")
+        and str(s2.id) in texto_serv.splitlines()[1]
+    )
     texto_rec = asyncio.run(_run("listar_reclamos", []))["texto"]
-    assert texto_rec.splitlines()[1].startswith("1. ") and "R2" in texto_rec.splitlines()[1]
+    assert (
+        texto_rec.splitlines()[1].startswith("1. ")
+        and "R2" in texto_rec.splitlines()[1]
+    )
     texto_cam = asyncio.run(_run("listar_camaras", []))["texto"]
-    assert texto_cam.splitlines()[1].startswith("1. ") and "C2" in texto_cam.splitlines()[1]
+    assert (
+        texto_cam.splitlines()[1].startswith("1. ")
+        and "C2" in texto_cam.splitlines()[1]
+    )
 
     # Datos extra para las nuevas tablas
     with bd.SessionLocal() as s:
@@ -102,28 +122,52 @@ def test_listar_descendente():
         s.refresh(car2)
 
     with bd.SessionLocal() as s:
-        s.add_all([
-            bd.Conversacion(user_id="1", mensaje="hola", respuesta="hi", modo="t"),
-            bd.Conversacion(user_id="2", mensaje="chau", respuesta="bye", modo="t"),
-        ])
+        s.add_all(
+            [
+                bd.Conversacion(user_id="1", mensaje="hola", respuesta="hi", modo="t"),
+                bd.Conversacion(user_id="2", mensaje="chau", respuesta="bye", modo="t"),
+            ]
+        )
         s.commit()
     bd.crear_ingreso(s1.id, "Cam1", usuario="u1")
     bd.crear_ingreso(s2.id, "Cam2", usuario="u2")
-    bd.crear_tarea_programada(datetime(2024, 1, 1, 8), datetime(2024, 1, 1, 9), "A", [s1.id])
-    t2 = bd.crear_tarea_programada(datetime(2024, 1, 2, 8), datetime(2024, 1, 2, 9), "B", [s2.id])
+    bd.crear_tarea_programada(
+        datetime(2024, 1, 1, 8), datetime(2024, 1, 1, 9), "A", [s1.id]
+    )[0]
+    t2, _ = bd.crear_tarea_programada(
+        datetime(2024, 1, 2, 8), datetime(2024, 1, 2, 9), "B", [s2.id]
+    )
 
     texto_cli = asyncio.run(_run("listar_clientes", []))["texto"]
-    assert texto_cli.splitlines()[1].startswith("1. ") and "Cli2" in texto_cli.splitlines()[1]
+    assert (
+        texto_cli.splitlines()[1].startswith("1. ")
+        and "Cli2" in texto_cli.splitlines()[1]
+    )
     texto_car = asyncio.run(_run("listar_carriers", []))["texto"]
-    assert texto_car.splitlines()[1].startswith("1. ") and "Car2" in texto_car.splitlines()[1]
+    assert (
+        texto_car.splitlines()[1].startswith("1. ")
+        and "Car2" in texto_car.splitlines()[1]
+    )
     texto_conv = asyncio.run(_run("listar_conversaciones", []))["texto"]
-    assert texto_conv.splitlines()[1].startswith("1. ") and "chau" in texto_conv.splitlines()[1]
+    assert (
+        texto_conv.splitlines()[1].startswith("1. ")
+        and "chau" in texto_conv.splitlines()[1]
+    )
     texto_ing = asyncio.run(_run("listar_ingresos", []))["texto"]
-    assert texto_ing.splitlines()[1].startswith("1. ") and "Cam2" in texto_ing.splitlines()[1]
+    assert (
+        texto_ing.splitlines()[1].startswith("1. ")
+        and "Cam2" in texto_ing.splitlines()[1]
+    )
     texto_tareas = asyncio.run(_run("listar_tareas_programadas", []))["texto"]
-    assert texto_tareas.splitlines()[1].startswith("1. ") and "B" in texto_tareas.splitlines()[1]
+    assert (
+        texto_tareas.splitlines()[1].startswith("1. ")
+        and "B" in texto_tareas.splitlines()[1]
+    )
     texto_rel = asyncio.run(_run("listar_tareas_servicio", []))["texto"]
-    assert texto_rel.splitlines()[1].startswith("1. ") and f"{t2.id}-{s2.id}" in texto_rel.splitlines()[1]
+    assert (
+        texto_rel.splitlines()[1].startswith("1. ")
+        and f"{t2.id}-{s2.id}" in texto_rel.splitlines()[1]
+    )
 
 
 def test_depurar_duplicados():

--- a/tests/test_tarea_programada.py
+++ b/tests/test_tarea_programada.py
@@ -1,14 +1,15 @@
 # Nombre de archivo: test_tarea_programada.py
 # Ubicación de archivo: tests/test_tarea_programada.py
 # User-provided custom instructions
-import sys
-import importlib
 import asyncio
-from types import ModuleType, SimpleNamespace
-from pathlib import Path
-from datetime import datetime
-from sqlalchemy.orm import sessionmaker
+import importlib
+import sys
 import tempfile
+from datetime import datetime
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+from sqlalchemy.orm import sessionmaker
 
 # Preparar ruta del paquete
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -143,6 +144,7 @@ def test_registrar_tarea_programada(tmp_path):
     assert enviados["cid"] == cli.id
     assert "Mantenimiento" in enviados["cuerpo"]
 
+
 def test_reenviar_aviso(tmp_path):
     global TEMP_DIR
     TEMP_DIR = tmp_path
@@ -180,7 +182,7 @@ def test_reenviar_aviso(tmp_path):
         s.refresh(cli)
 
     servicio = bd.crear_servicio(nombre="Srv", cliente="Cli2", cliente_id=cli.id)
-    tarea = bd.crear_tarea_programada(
+    tarea, _ = bd.crear_tarea_programada(
         datetime(2024, 1, 2, 8),
         datetime(2024, 1, 2, 10),
         "Mantenimiento",


### PR DESCRIPTION
## Resumen
- devolver bandera de creación en `crear_tarea_programada`
- propagarla en `email_utils.procesar_correo_a_tarea`
- actualizar handlers para mostrar `ID Carrier` y avisar si la tarea ya existía
- ajustar pruebas e incluir caso de archivo duplicado

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68508f8bfa948330b5e079dd394d5f1e